### PR TITLE
feat: add goreleaser for build and release steps

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,34 @@
+name: goreleaser
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: 1.21
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          version: latest
+          args: release --parallelism 1 --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ config.toml
 # build
 pb
 bin/
+dist/
 
 # OS Files
 .DS_Store

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,50 @@
+env:
+  - GO111MODULE=on
+  - CGO_ENABLED=0
+
+builds:
+  - binary: pb
+    id: pb
+    main: ./main.go
+    goos:
+      - windows
+      - darwin
+      - linux
+    goarch:
+      - amd64
+      - arm64
+    flags:
+      - -trimpath
+      - -tags=kqueue
+    ldflags:
+      - -s -w -X main.Version={{ .Version }} -X main.Commit={{ .ShortCommit }}
+
+archives:
+  - format: tar.gz
+    rlcp: true
+    files:
+      - README.md
+      - LICENSE
+
+dockers:
+  - id: pb
+    goos: linux
+    goarch: amd64
+    ids:
+      - pb
+    image_templates:
+      - "parseablehq/pb:{{ .Tag }}"
+      - "parseablehq/pb:latest"
+    skip_push: false
+    dockerfile: Dockerfile
+    use: docker
+    build_flag_templates:
+      - "--pull"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title=Parseable"
+      - "--label=maintainer=Parseable Team <hi@parseable.io>"
+      - "--label=org.opencontainers.image.vendor=Cloudnatively Pvt Ltd"
+      - "--label=org.opencontainers.image.licenses=AGPL-3.0"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--platform=linux/amd64"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM ubuntu:22.04
+RUN apt-get -y update && apt install -y ca-certificates
+WORKDIR /app
+COPY pb .
+ENTRYPOINT [ "./pb" ]


### PR DESCRIPTION
Closes https://github.com/parseablehq/pb/issues/8

### Test

```
goreleaser --snapshot --clean

 ./dist/pb_linux_amd64_v1/pb 
Error: no command or flag supplied
Usage:
  pb [flags]
  pb [command]

Available Commands:
  help        Help about any command
  profile     Manage profiles
  query       Open SQL query prompt
  stream      Manage streams
  user        Manage users
  version     Print version

Flags:
  -h, --help      help for pb
  -v, --version   Print version

Use "pb [command] --help" for more information about a command.
```

```
 docker run --rm parseablehq/pb profile

use profile command to configure (multiple) Parseable instances. Each profile takes a URL and credentials.

Usage:
  pb profile [command]

Available Commands:
  add         Add a new profile
  default     Set default profile to use with all commands
  list        List all added profiles
  remove      Delete a profile

Flags:
  -h, --help   help for profile

Use "pb profile [command] --help" for more information about a command.
```

### Notes

- Not really sure why `-tags=kqueue` is added in Makefile. For now, I've kept it consistent in `.goreleaser.yml`, but if this has to be changed, we can.
- The `ldflags` part (`go run buildscripts/gen-ldflags.go $(VERSION)`) is a bit complicated to run in `.goreleaser.yml`. I ran it manually and templated the same string in `.goreleaser.yml`, hope that's fine.


Let me know if any changes are required!