### PR TITLE
Add Autocomplete Feature to pb CLI 

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,3 +113,27 @@ Version command prints the version of pb and the Parseable Server it is configur
 ```bash
 pb version
 ```
+
+### Add Autocomplete
+
+To enable autocomplete for pb, run the following command according to your shell:
+
+For bash:
+```bash
+pb autocomplete bash > /etc/bash_completion.d/pb
+source /etc/bash_completion.d/pb
+```
+
+For zsh:
+```zsh
+pb autocomplete zsh > /usr/local/share/zsh/site-functions/_pb
+autoload -U compinit && compinit
+```
+
+For powershell
+```powershell
+pb autocomplete powershell > $env:USERPROFILE\Documents\PowerShell\pb_complete.ps1
+. $PROFILE
+```
+
+

--- a/cmd/autocomplete.go
+++ b/cmd/autocomplete.go
@@ -1,0 +1,52 @@
+
+// Copyright (c) 2024 Parseable, Inc
+//
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cmd
+
+import (
+    "fmt"
+    "os"
+
+    "github.com/spf13/cobra"
+)
+
+// AutocompleteCmd represents the autocomplete command
+var AutocompleteCmd = &cobra.Command{
+    Use:   "autocomplete [bash|zsh|powershell]",
+    Short: "Generate autocomplete script",
+    Long:  `Generate autocomplete script for bash, zsh, or powershell`,
+    Args:  cobra.ExactArgs(1),
+    RunE: func(cmd *cobra.Command, args []string) error {
+        var err error
+        switch args[0] {
+        case "bash":
+            err = cmd.Root().GenBashCompletion(os.Stdout)
+        case "zsh":
+            err = cmd.Root().GenZshCompletion(os.Stdout)
+        case "powershell":
+            err = cmd.Root().GenPowerShellCompletionWithDesc(os.Stdout)
+        default:
+            err = fmt.Errorf("unsupported shell type: %s. Only bash, zsh, and powershell are supported", args[0])
+        }
+
+        if err != nil {
+            return fmt.Errorf("error generating autocomplete script: %w", err)
+        }
+
+        return nil
+    },
+}

--- a/main.go
+++ b/main.go
@@ -112,6 +112,8 @@ func main() {
 	cli.AddCommand(role)
 	cli.AddCommand(cmd.TailCmd)
 
+	cli.AddCommand(cmd.AutocompleteCmd)
+
 	// Set as command
 	cmd.VersionCmd.Run = func(_ *cobra.Command, _ []string) {
 		cmd.PrintVersion(Version, Commit)


### PR DESCRIPTION
**Title:** Add Autocomplete Feature to pb CLI 

**Description:**

This PR introduces an autocomplete feature for the CLI application to enhance user experience by providing command and flag suggestions. This change aims to make the CLI easier to use, especially for new users.

**Changes:**

- Added autocomplete.go to handle the generation of autocomplete scripts.
- Bash, Zsh, and PowerShell are supported.
- Modified main.go to include the new autocomplete command.
- Updated Makefile to install autocomplete scripts during the installation process.
- Added documentation for enabling autocomplete in different shells.

How to Test:

1. Build the CLI application using make build.
2. Install the CLI using make install.
3. Verify the autocomplete setup by running the CLI and typing commands with double tab to see if suggestions appear.
4. Test in different shells:
  - Bash: `source /etc/bash_completion.d/pb`
  - Zsh: `source /usr/local/share/zsh/site-functions/_pb`
  - PowerShell: . `$env:USERPROFILE\Documents\PowerShell\pb_complete.ps1`
 
