### PR TITLE
Feature:Create Saved Filter

### DIFF
--- a/cmd/query.go
+++ b/cmd/query.go
@@ -41,7 +41,7 @@ var (
 	defaultEnd   = "now"
 
 	// save filter flags
-	saveFilterFlag = "save-as"
+	saveFilterFlag     = "save-as"
 	saveFilterTimeFlag = "keep-time"
 
 	interactiveFlag      = "interactive"
@@ -64,7 +64,7 @@ var query = &cobra.Command{
 			fmt.Println("please enter your query")
 			fmt.Printf("Example:\n  pb query run \"select * from frontend\" --from=10m --to=now\n")
 			return nil
-		} else{
+		} else {
 			query = args[0]
 		}
 
@@ -95,13 +95,13 @@ var query = &cobra.Command{
 		}
 
 		keepTime, err := command.Flags().GetBool(saveFilterTimeFlag)
-		if err != nil{
+		if err != nil {
 			return err
 		}
 
 		filterName, err := command.Flags().GetString(saveFilterFlag)
-		filterNameTrimmed := strings.Trim(filterName," ")
-		if err !=nil{
+		filterNameTrimmed := strings.Trim(filterName, " ")
+		if err != nil {
 			return err
 		}
 
@@ -118,16 +118,15 @@ var query = &cobra.Command{
 		if len(filterNameTrimmed) == 0 {
 			fmt.Println("Enter a filter name")
 			return nil
-		} else if filterName != "DEFAULT_FILTER_NAME" { 
-			if keepTime{
-			saveFilter(query, filterNameTrimmed,start, end)
+		} else if filterName != "DEFAULT_FILTER_NAME" {
+			if keepTime {
+				saveFilter(query, filterNameTrimmed, start, end)
 
-			} else{
-				saveFilter(query,filterNameTrimmed, "1m", "now")
+			} else {
+				saveFilter(query, filterNameTrimmed, "1m", "now")
 			}
 			return nil
-		} 
-
+		}
 
 		client := DefaultClient()
 		return fetchData(&client, query, start, end)
@@ -139,7 +138,7 @@ var QueryCmd = func() *cobra.Command {
 	query.Flags().BoolP(interactiveFlag, interactiveFlagShort, false, "open the query result in interactive mode")
 	query.Flags().StringP(startFlag, startFlagShort, defaultStart, "Start time for query. Takes date as '2024-10-12T07:20:50.52Z' or string like '10m', '1hr'")
 	query.Flags().StringP(endFlag, endFlagShort, defaultEnd, "End time for query. Takes date as '2024-10-12T07:20:50.52Z' or 'now'")
-	query.Flags().String(saveFilterFlag,"DEFAULT_FILTER_NAME", "Save a query filter") // save filter flag. Default value = DEFAULT_FILTER_NAME (type string)
+	query.Flags().String(saveFilterFlag, "DEFAULT_FILTER_NAME", "Save a query filter") // save filter flag. Default value = DEFAULT_FILTER_NAME (type string)
 	return query
 }()
 
@@ -230,26 +229,25 @@ func parseTime(start, end string) (time.Time, time.Time, error) {
 	return startTime, endTime, nil
 }
 
-
 // fires a request to the server to save the filter with the associated user and stream
-func saveFilter( query string,filterName string, startTime string, endTime string) (err error) {
-	client := DefaultClient();
-	userConfig,err := config.ReadConfigFromFile()
-	if err != nil{
+func saveFilter(query string, filterName string, startTime string, endTime string) (err error) {
+	client := DefaultClient()
+	userConfig, err := config.ReadConfigFromFile()
+	if err != nil {
 		return err
 	}
 	var userName string
 	if profile, ok := userConfig.Profiles[userConfig.DefaultProfile]; ok {
-        userName = profile.Username
-    } else {
-        fmt.Println("Default profile not found.")
+		userName = profile.Username
+	} else {
+		fmt.Println("Default profile not found.")
 		return
-    }
+	}
 	index := strings.Index(query, "from")
 	streamName := strings.TrimSpace(query[index+len("from"):])
 
-	start,end,err := parseTimeToUTC(startTime,endTime)
-	if err !=nil{
+	start, end, err := parseTimeToUTC(startTime, endTime)
+	if err != nil {
 		fmt.Println("Oops something went wrong!!!!")
 		return
 	}
@@ -273,9 +271,9 @@ func saveFilter( query string,filterName string, startTime string, endTime strin
     "time_filter": %s  
     }`
 
-	queryField := fmt.Sprintf(queryTemplate,query)
+	queryField := fmt.Sprintf(queryTemplate, query)
 	timeField := fmt.Sprintf(timeTemplate, start, end)
-	final := fmt.Sprintf(saveFilterTemplate, streamName, filterName,userName,queryField,timeField)
+	final := fmt.Sprintf(saveFilterTemplate, streamName, filterName, userName, queryField, timeField)
 
 	req, err := client.NewRequest("POST", "filters", bytes.NewBuffer([]byte(final)))
 	if err != nil {
@@ -291,39 +289,37 @@ func saveFilter( query string,filterName string, startTime string, endTime strin
 		fmt.Printf("\n%s filter saved\n", filterName)
 	}
 
-		return err
+	return err
 }
-
-
 
 // parses a time duration to supported utc format
 func parseTimeToUTC(start, end string) (time.Time, time.Time, error) {
-    if start == defaultStart && end == defaultEnd {
-        now := time.Now().UTC()
-        return now.Add(-1 * time.Minute), now, nil
-    }
+	if start == defaultStart && end == defaultEnd {
+		now := time.Now().UTC()
+		return now.Add(-1 * time.Minute), now, nil
+	}
 
-    startTime, err := time.Parse(time.RFC3339, start)
-    if err != nil {
-        duration, err := time.ParseDuration(start)
-        if err != nil {
-            return time.Time{}, time.Time{}, err
-        }
-        startTime = time.Now().Add(-1 * duration).UTC()
-    } else {
-        startTime = startTime.UTC()
-    }
+	startTime, err := time.Parse(time.RFC3339, start)
+	if err != nil {
+		duration, err := time.ParseDuration(start)
+		if err != nil {
+			return time.Time{}, time.Time{}, err
+		}
+		startTime = time.Now().Add(-1 * duration).UTC()
+	} else {
+		startTime = startTime.UTC()
+	}
 
-    endTime, err := time.Parse(time.RFC3339, end)
-    if err != nil {
-        if end == "now" {
-            endTime = time.Now().UTC()
-        } else {
-            return time.Time{}, time.Time{}, err
-        }
-    } else {
-        endTime = endTime.UTC()
-    }
+	endTime, err := time.Parse(time.RFC3339, end)
+	if err != nil {
+		if end == "now" {
+			endTime = time.Now().UTC()
+		} else {
+			return time.Time{}, time.Time{}, err
+		}
+	} else {
+		endTime = endTime.UTC()
+	}
 
-    return startTime, endTime, nil
+	return startTime, endTime, nil
 }

--- a/cmd/query.go
+++ b/cmd/query.go
@@ -125,7 +125,6 @@ var query = &cobra.Command{
 			} else {
 				saveFilter(query, filterNameTrimmed, "1m", "now")
 			}
-			return nil
 		}
 
 		client := DefaultClient()

--- a/cmd/query.go
+++ b/cmd/query.go
@@ -101,10 +101,14 @@ var query = &cobra.Command{
 		}
 
 		filterName, err := command.Flags().GetString(saveFilterFlag)
-		filterNameTrimmed := strings.Trim(filterName, " ")
 		if err != nil {
 			return err
 		}
+		if filterName=="" {
+			filterName = "DEFAULT_FILTER_NAME"
+		}
+		filterNameTrimmed := strings.Trim(filterName, " ")
+
 
 		if interactive {
 			p := tea.NewProgram(model.NewQueryModel(DefaultProfile, query, startTime, endTime), tea.WithAltScreen())
@@ -117,9 +121,9 @@ var query = &cobra.Command{
 
 		// Checks if there is filter name which is not empty. Empty filter name wont be allowed
 		if len(filterNameTrimmed) == 0 {
-			fmt.Println("Enter a filter name")
+			fmt.Println("please provide a filter name")
 			return nil
-		} else if filterName != "FILTER_NAME" {
+		} else if filterName != "DEFAULT_FILTER_NAME" {
 			if keepTime {
 				createFilterWithTime(query, filterNameTrimmed, start, end)
 
@@ -127,10 +131,13 @@ var query = &cobra.Command{
 				// if there is no keep time filter pass empty values for startTime and endTime
 				createFilter(query, filterNameTrimmed)
 			}
-		} else if filterName == "FILTER_NAME" && keepTime{
-			 fmt.Println("filter name was not found")
+		} else if filterName == "DEFAULT_FILTER_NAME" && keepTime{
+			 fmt.Println("please provide a filter name")
 			 command.Help()
 			 return nil
+		}else if filterName=="DEFAULT_FILTER_NAME"{
+			fmt.Println("please provide a filter name")
+			return nil
 		}
 
 		client := DefaultClient()
@@ -143,7 +150,7 @@ var QueryCmd = func() *cobra.Command {
 	query.Flags().BoolP(interactiveFlag, interactiveFlagShort, false, "open the query result in interactive mode")
 	query.Flags().StringP(startFlag, startFlagShort, defaultStart, "Start time for query. Takes date as '2024-10-12T07:20:50.52Z' or string like '10m', '1hr'")
 	query.Flags().StringP(endFlag, endFlagShort, defaultEnd, "End time for query. Takes date as '2024-10-12T07:20:50.52Z' or 'now'")
-	query.Flags().StringP(saveFilterFlag, saveFilterShort ,"FILTER_NAME", "Save a query filter") // save filter flag. Default value = FILTER_NAME (type string)
+	query.Flags().StringP(saveFilterFlag, saveFilterShort , "", "Save a query filter") // save filter flag. Default value = FILTER_NAME (type string)
 	return query
 }()
 

--- a/cmd/query.go
+++ b/cmd/query.go
@@ -130,7 +130,7 @@ var query = &cobra.Command{
 		} else if filterName == "FILTER_NAME" && keepTime{
 			 fmt.Println("filter name was not found")
 			 command.Help()
-			 fmt.Printf("\n")
+			 return nil
 		}
 
 		client := DefaultClient()

--- a/cmd/query.go
+++ b/cmd/query.go
@@ -135,9 +135,6 @@ var query = &cobra.Command{
 			 fmt.Println("please provide a filter name")
 			 command.Help()
 			 return nil
-		}else if filterName=="DEFAULT_FILTER_NAME"{
-			fmt.Println("please provide a filter name")
-			return nil
 		}
 
 		client := DefaultClient()

--- a/cmd/query.go
+++ b/cmd/query.go
@@ -39,10 +39,10 @@ var (
 	defaultEnd   = "now"
 
 	// save filter flags
-	saveFilterFlag     = "save-as"
-	saveFilterShort	   = "s"
+	saveFilterFlag  = "save-as"
+	saveFilterShort = "s"
 	//save filter with time flags
-	saveFilterTimeFlag = "with-time"
+	saveFilterTimeFlag  = "with-time"
 	saveFilterTimeShort = "w"
 
 	interactiveFlag      = "interactive"
@@ -104,11 +104,7 @@ var query = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		if filterName=="" {
-			filterName = "DEFAULT_FILTER_NAME"
-		}
 		filterNameTrimmed := strings.Trim(filterName, " ")
-
 
 		if interactive {
 			p := tea.NewProgram(model.NewQueryModel(DefaultProfile, query, startTime, endTime), tea.WithAltScreen())
@@ -120,21 +116,24 @@ var query = &cobra.Command{
 		}
 
 		// Checks if there is filter name which is not empty. Empty filter name wont be allowed
-		if len(filterNameTrimmed) == 0 {
-			fmt.Println("please provide a filter name")
-			return nil
-		} else if filterName != "DEFAULT_FILTER_NAME" {
-			if keepTime {
-				createFilterWithTime(query, filterNameTrimmed, start, end)
+		if command.Flags().Changed(saveFilterFlag) {
+			if filterName == "" || len(filterNameTrimmed) == 0 || filterName == "=" {
+				fmt.Println("please provide a filter name")
+				command.Help()
+				return nil
+			} else if filterName != "" {
+				if keepTime {
+					createFilterWithTime(query, filterNameTrimmed, start, end)
 
-			} else {
-				// if there is no keep time filter pass empty values for startTime and endTime
-				createFilter(query, filterNameTrimmed)
+				} else {
+					// if there is no keep time filter pass empty values for startTime and endTime
+					createFilter(query, filterNameTrimmed)
+				}
 			}
-		} else if filterName == "DEFAULT_FILTER_NAME" && keepTime{
-			 fmt.Println("please provide a filter name")
-			 command.Help()
-			 return nil
+		} else if filterName == "" && keepTime {
+			fmt.Println("please provide a filter name")
+			command.Help()
+			return nil
 		}
 
 		client := DefaultClient()
@@ -143,11 +142,11 @@ var query = &cobra.Command{
 }
 
 var QueryCmd = func() *cobra.Command {
-	query.Flags().BoolP(saveFilterTimeFlag, saveFilterTimeShort,false, "Save the time range associated in the query to the filter") // save time for a filter flag; default value = false (boolean type)
+	query.Flags().BoolP(saveFilterTimeFlag, saveFilterTimeShort, false, "Save the time range associated in the query to the filter") // save time for a filter flag; default value = false (boolean type)
 	query.Flags().BoolP(interactiveFlag, interactiveFlagShort, false, "open the query result in interactive mode")
 	query.Flags().StringP(startFlag, startFlagShort, defaultStart, "Start time for query. Takes date as '2024-10-12T07:20:50.52Z' or string like '10m', '1hr'")
 	query.Flags().StringP(endFlag, endFlagShort, defaultEnd, "End time for query. Takes date as '2024-10-12T07:20:50.52Z' or 'now'")
-	query.Flags().StringP(saveFilterFlag, saveFilterShort , "", "Save a query filter") // save filter flag. Default value = FILTER_NAME (type string)
+	query.Flags().StringP(saveFilterFlag, saveFilterShort, "", "Save a query filter") // save filter flag. Default value = FILTER_NAME (type string)
 	return query
 }()
 

--- a/main.go
+++ b/main.go
@@ -134,13 +134,22 @@ func main() {
 	cli.CompletionOptions.HiddenDefaultCmd = true
 
 	// create a default profile if file does not exist
-	if _, err := config.ReadConfigFromFile(); os.IsNotExist(err) {
+	if previousConfig, err := config.ReadConfigFromFile(); os.IsNotExist(err) {
 		conf := config.Config{
 			Profiles:       map[string]config.Profile{"demo": defaultInitialProfile()},
 			DefaultProfile: "demo",
 		}
 		config.WriteConfigToFile(&conf)
-	}
+	} else{ 
+		_,exists := previousConfig.Profiles["demo"]; 
+		if exists{
+			conf := config.Config{
+				Profiles:       map[string]config.Profile{"demo": defaultInitialProfile()},
+				DefaultProfile: "demo",
+			}
+			config.WriteConfigToFile(&conf)
+		}
+}
 
 	err := cli.Execute()
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -85,6 +85,13 @@ var stream = &cobra.Command{
 	PersistentPreRunE: cmd.PreRunDefaultProfile,
 }
 
+var query = &cobra.Command{
+	Use: 		"query",
+	Short:   "Run SQL query on a log stream",
+	Long:    "\nRun SQL query on a log stream. Default output format is json. Use -i flag to open interactive table view.",
+	PersistentPreRunE: cmd.PreRunDefaultProfile,
+}
+
 func main() {
 	profile.AddCommand(cmd.AddProfileCmd)
 	profile.AddCommand(cmd.RemoveProfileCmd)
@@ -105,8 +112,10 @@ func main() {
 	stream.AddCommand(cmd.ListStreamCmd)
 	stream.AddCommand(cmd.StatStreamCmd)
 
+	query.AddCommand(cmd.QueryCmd)
+
 	cli.AddCommand(profile)
-	cli.AddCommand(cmd.QueryCmd)
+	cli.AddCommand(query)
 	cli.AddCommand(stream)
 	cli.AddCommand(user)
 	cli.AddCommand(role)

--- a/main.go
+++ b/main.go
@@ -141,6 +141,7 @@ func main() {
 		}
 		config.WriteConfigToFile(&conf)
 	} else{ 
+		//updates the demo profile for existing users
 		_,exists := previousConfig.Profiles["demo"]; 
 		if exists{
 			conf := config.Config{

--- a/main.go
+++ b/main.go
@@ -86,9 +86,9 @@ var stream = &cobra.Command{
 }
 
 var query = &cobra.Command{
-	Use: 		"query",
-	Short:   "Run SQL query on a log stream",
-	Long:    "\nRun SQL query on a log stream. Default output format is json. Use -i flag to open interactive table view.",
+	Use:               "query",
+	Short:             "Run SQL query on a log stream",
+	Long:              "\nRun SQL query on a log stream. Default output format is json. Use -i flag to open interactive table view.",
 	PersistentPreRunE: cmd.PreRunDefaultProfile,
 }
 
@@ -140,17 +140,17 @@ func main() {
 			DefaultProfile: "demo",
 		}
 		config.WriteConfigToFile(&conf)
-	} else{ 
+	} else {
 		//updates the demo profile for existing users
-		_,exists := previousConfig.Profiles["demo"]; 
-		if exists{
+		_, exists := previousConfig.Profiles["demo"]
+		if exists {
 			conf := config.Config{
 				Profiles:       map[string]config.Profile{"demo": defaultInitialProfile()},
 				DefaultProfile: "demo",
 			}
 			config.WriteConfigToFile(&conf)
 		}
-}
+	}
 
 	err := cli.Execute()
 	if err != nil {


### PR DESCRIPTION
This PR allows the user to create a saved filter using the command pb query run <query> --save-as.
Changes: to run a query the new command is pb query run use pb query --help
and
pb query run --help for more info.
The --save-as command accepts a string  which is assigned as the filter name.
--keep-time command is a boolean if present it will take the value of --from flag and --to flag  and save then with the filter for future use.

saveFilter function accepts a query , filter name , start time and end time , and makes a request to the parseable server to save the filter . The function will automatically extract the stream name from the query . 

parseTimeToUTC takes 2 arguments in string type which should of time duration format (1s, 1m 1h, 1d ... etc) and output 
timeDate of these respective duration in UTC format.