### PR TITLE
simplifies k8s client creation with singleton pattern

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,5 @@
+version: 1
+
 linters:
   disable-all: true
   enable:

--- a/cmd/cluster.go
+++ b/cmd/cluster.go
@@ -55,8 +55,13 @@ var ListOssCmd = &cobra.Command{
 			log.Fatalf("Failed to prompt for kubernetes context: %v", err)
 		}
 
+		k8sClient, err := common.CreateK8sClient()
+		if err != nil {
+			log.Fatalf("Error creating k8s client %v", err)
+		}
+
 		// Read the installer data from the ConfigMap
-		entries, err := common.ReadInstallerConfigMap()
+		entries, err := common.ReadInstallerConfigMap(k8sClient)
 		if err != nil {
 			log.Fatalf("Failed to list servers: %v", err)
 		}
@@ -90,8 +95,13 @@ var ShowValuesCmd = &cobra.Command{
 			log.Fatalf("Failed to prompt for Kubernetes context: %v", err)
 		}
 
+		k8sClient, err := common.CreateK8sClient()
+		if err != nil {
+			log.Fatalf("Error creating k8s client %v", err)
+		}
+
 		// Read the installer data from the ConfigMap
-		entries, err := common.ReadInstallerConfigMap()
+		entries, err := common.ReadInstallerConfigMap(k8sClient)
 		if err != nil {
 			log.Fatalf("Failed to list OSS servers: %v", err)
 		}
@@ -139,8 +149,13 @@ var UninstallOssCmd = &cobra.Command{
 			log.Fatalf("Failed to prompt for Kubernetes context: %v", err)
 		}
 
+		k8sClient, err := common.CreateK8sClient()
+		if err != nil {
+			log.Fatalf("Error creating k8s client %v", err)
+		}
+
 		// Read the installer data from the ConfigMap
-		entries, err := common.ReadInstallerConfigMap()
+		entries, err := common.ReadInstallerConfigMap(k8sClient)
 		if err != nil {
 			log.Fatalf("Failed to fetch OSS servers: %v", err)
 		}
@@ -176,12 +191,12 @@ var UninstallOssCmd = &cobra.Command{
 		}
 
 		// Remove entry from ConfigMap
-		if err := common.RemoveInstallerEntry(selectedCluster.Name); err != nil {
+		if err := common.RemoveInstallerEntry(selectedCluster.Name, k8sClient); err != nil {
 			log.Fatalf("Failed to remove entry from ConfigMap: %v", err)
 		}
 
 		// Delete secret
-		if err := deleteSecret(selectedCluster.Namespace, "parseable-env-secret"); err != nil {
+		if err := deleteSecret(selectedCluster.Namespace, "parseable-env-secret", k8sClient); err != nil {
 			log.Printf("Warning: Failed to delete secret 'parseable-env-secret': %v", err)
 		} else {
 			fmt.Println(common.Green + "Secret 'parseable-env-secret' deleted successfully." + common.Reset)
@@ -217,18 +232,9 @@ func uninstallCluster(entry common.InstallerEntry) error {
 	return nil
 }
 
-func deleteSecret(namespace, secretName string) error {
-	config, err := common.LoadKubeConfig()
-	if err != nil {
-		return fmt.Errorf("failed to create Kubernetes client: %v", err)
-	}
-
-	clientset, err := kubernetes.NewForConfig(config)
-	if err != nil {
-		return fmt.Errorf("failed to create Kubernetes client: %w", err)
-	}
-
-	err = clientset.CoreV1().Secrets(namespace).Delete(context.TODO(), "parseable-env-secret", metav1.DeleteOptions{})
+func deleteSecret(namespace, secretName string, k8sClient *kubernetes.Clientset) error {
+	// Delete the secrets
+	err := k8sClient.CoreV1().Secrets(namespace).Delete(context.TODO(), "parseable-env-secret", metav1.DeleteOptions{})
 	if err != nil {
 		return fmt.Errorf("failed to delete secret '%s': %v", secretName, err)
 	}

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -56,21 +56,9 @@ type InstallerEntry struct {
 }
 
 // ReadInstallerConfigMap fetches and parses installer data from a ConfigMap
-func ReadInstallerConfigMap() ([]InstallerEntry, error) {
-
-	// Load kubeconfig and create a Kubernetes client
-	config, err := LoadKubeConfig()
-	if err != nil {
-		return nil, fmt.Errorf("failed to load kubeconfig: %w", err)
-	}
-
-	clientset, err := kubernetes.NewForConfig(config)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create Kubernetes client: %w", err)
-	}
-
+func ReadInstallerConfigMap(k8sclient *kubernetes.Clientset) ([]InstallerEntry, error) {
 	// Get the ConfigMap
-	cm, err := clientset.CoreV1().ConfigMaps(namespace).Get(context.TODO(), configMapName, metav1.GetOptions{})
+	cm, err := k8sclient.CoreV1().ConfigMaps(namespace).Get(context.TODO(), configMapName, metav1.GetOptions{})
 	if err != nil {
 		if apiErrors.IsNotFound(err) {
 			fmt.Println(Yellow + "\nNo existing Parseable OSS clusters found.\n" + Reset)
@@ -100,6 +88,20 @@ func ReadInstallerConfigMap() ([]InstallerEntry, error) {
 func LoadKubeConfig() (*rest.Config, error) {
 	kubeconfig := clientcmd.NewDefaultClientConfigLoadingRules().GetDefaultFilename()
 	return clientcmd.BuildConfigFromFlags("", kubeconfig)
+}
+
+func CreateK8sClient() (*kubernetes.Clientset, error) {
+	// Load kubeconfig and create a Kubernetes client
+	config, err := LoadKubeConfig()
+	if err != nil {
+		return nil, fmt.Errorf("failed to load kubeconfig: %w", err)
+	}
+
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create Kubernetes client: %w", err)
+	}
+	return clientset, nil
 }
 
 // PromptK8sContext retrieves Kubernetes contexts from kubeconfig.
@@ -220,20 +222,9 @@ func CreateDeploymentSpinner(infoMsg string) *spinner.Spinner {
 
 	return s
 }
-func RemoveInstallerEntry(name string) error {
-	// Load kubeconfig and create a Kubernetes client
-	config, err := LoadKubeConfig()
-	if err != nil {
-		return fmt.Errorf("failed to load kubeconfig: %w", err)
-	}
-
-	clientset, err := kubernetes.NewForConfig(config)
-	if err != nil {
-		return fmt.Errorf("failed to create Kubernetes client: %w", err)
-	}
-
+func RemoveInstallerEntry(name string, k8sclient *kubernetes.Clientset) error {
 	// Fetch the ConfigMap
-	configMap, err := clientset.CoreV1().ConfigMaps(namespace).Get(context.TODO(), configMapName, metav1.GetOptions{})
+	configMap, err := k8sclient.CoreV1().ConfigMaps(namespace).Get(context.TODO(), configMapName, metav1.GetOptions{})
 	if err != nil {
 		return fmt.Errorf("failed to fetch ConfigMap: %v", err)
 	}
@@ -271,7 +262,7 @@ func RemoveInstallerEntry(name string) error {
 	configMap.Data["installer-data"] = string(updatedData)
 
 	// Update the ConfigMap in Kubernetes
-	_, err = clientset.CoreV1().ConfigMaps(namespace).Update(context.TODO(), configMap, metav1.UpdateOptions{})
+	_, err = k8sclient.CoreV1().ConfigMaps(namespace).Update(context.TODO(), configMap, metav1.UpdateOptions{})
 	if err != nil {
 		return fmt.Errorf("failed to update ConfigMap: %v", err)
 	}


### PR DESCRIPTION
K8s client was created multiple time within a single function and created directly from config each time. This PR simplifies the client creation and creates one client per command. It also introduces distinct error regarding client creation which is useful for debugging.    

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved efficiency by reusing a single Kubernetes client across multiple operations, reducing redundant client creation.
  - Enhanced error handling for Kubernetes client creation failures.
- **Chores**
  - Streamlined internal logic for interacting with Kubernetes resources.
- **Chores**
  - Updated linting configuration to specify golangci-lint version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->