### PR TITLE
chore: stabilize Makefile, removed outdated tooling and upgrade versions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,11 +10,11 @@ jobs:
       - name: Checkout the code
         uses: actions/checkout@v4
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
-          go-version: "1.23.0"
+          go-version: "1.25.0"
       - name: Install gofumpt
-        run: go install mvdan.cc/gofumpt@latest
+        run: go install mvdan.cc/gofumpt@v0.7.0
       - name: Run gofumpt
         run: gofumpt -l -w .
       - name: make verification

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ go.work
 
 .vscode/
 config.toml
+CLAUDE.md
 
 # build
 pb

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,28 +1,49 @@
+version: "2"
+
 linters:
-  disable-all: true
+  default: none
   enable:
-    - typecheck
-    - goimports
     - misspell
     - govet
     - revive
     - ineffassign
     - gomodguard
-    - gofmt
     - unused
-
-linters-settings:
-  golint:
-    min-confidence: 0
-
-  misspell:
-    locale: US
-
-issues:
-  exclude-use-default: false
-  exclude:
-    - instead of using struct literal
-    - should have a package comment
-    - should have comment or be unexported
-    - time-naming
-    - error strings should not be capitalized or end with punctuation or a newline
+    - staticcheck
+  settings:
+    staticcheck:
+      checks:
+        - "all"
+        - "-ST1000"
+        - "-ST1003"
+        - "-ST1005"
+        - "-ST1016"
+        - "-ST1020"
+        - "-ST1021"
+        - "-ST1022"
+        - "-ST1023"
+    misspell:
+      locale: US
+  exclusions:
+    presets: []
+    rules:
+      - text: "instead of using struct literal"
+        linters:
+        - revive
+      - text: "should have a package comment"
+        linters:
+          - revive
+      - text: "should have comment or be unexported"
+        linters:
+          - revive
+      - text: "time-naming"
+        linters:
+        - revive
+      - text: "error strings should not be capitalized or end with punctuation or a newline"
+        linters:
+          - revive
+          
+formatters:
+  enable:
+    - gofmt
+    - goimports

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,14 @@
 PWD := $(shell pwd)
 GOPATH := $(shell go env GOPATH)
-VERSION ?= $(shell git describe --tags)
+# This is just for development purposes. The version is determined at build time using git tags.
+VERSION ?= $(shell git describe --tags 2>/dev/null || echo "dev")
 TAG ?= "parseablehq/pb:$(VERSION)"
 LDFLAGS := $(shell go run buildscripts/gen-ldflags.go $(VERSION))
 
 GOARCH := $(shell go env GOARCH)
 GOOS := $(shell go env GOOS)
-GO111MODULE=on
+
+GOLANGCI_LINT_VERSION := v2.11.4
 
 all: build
 
@@ -15,11 +17,9 @@ checks:
 	@(env bash $(PWD)/buildscripts/checkdeps.sh)
 
 getdeps:
-	@GO111MODULE=on
 	@mkdir -p ${GOPATH}/bin
-	@echo "Installing golangci-lint" && curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GOPATH)/bin
-	@echo "Installing stringer" && go install -v golang.org/x/tools/cmd/stringer@latest
-	@echo "Installing staticheck" && go install honnef.co/go/tools/cmd/staticcheck@latest
+	@echo "Installing golangci-lint $(GOLANGCI_LINT_VERSION)"
+	@curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GOPATH)/bin $(GOLANGCI_LINT_VERSION)
 
 crosscompile:
 	@(env bash $(PWD)/buildscripts/cross-compile.sh)
@@ -31,17 +31,16 @@ docker: build
 
 vet:
 	@echo "Running $@"
-	@GO111MODULE=on go vet $(PWD)/...
+	@go vet $(PWD)/...
 
 lint:
 	@echo "Running $@ check"
-	@GO111MODULE=on ${GOPATH}/bin/golangci-lint run --timeout=5m --config ./.golangci.yml
-	@GO111MODULE=on ${GOPATH}/bin/staticcheck -tests=false -checks="all,-ST1000,-ST1003,-ST1016,-ST1020,-ST1021,-ST1022,-ST1023,-ST1005" ./...
+	@${GOPATH}/bin/golangci-lint run --timeout=5m --config ./.golangci.yml
 
 # Builds pb locally.
 build: checks
 	@echo "Building pb binary to './pb'"
-	@GO111MODULE=on CGO_ENABLED=0 go build -trimpath -tags kqueue --ldflags "$(LDFLAGS)" -o $(PWD)/pb
+	@CGO_ENABLED=0 go build -trimpath -tags kqueue --ldflags "$(LDFLAGS)" -o $(PWD)/pb
 
 # Build pb for all supported platforms.
 build-release: verifiers crosscompile

--- a/buildscripts/checkdeps.sh
+++ b/buildscripts/checkdeps.sh
@@ -25,7 +25,7 @@ _init() {
 
     ## Minimum required versions for build dependencies
     GIT_VERSION="1.0"
-    GO_VERSION="1.13"
+    GO_VERSION="1.25"
     OSX_VERSION="10.8"
     KNAME=$(uname -s)
     ARCH=$(uname -m)

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module pb
 
-go 1.23.0
+go 1.25.0
 
-toolchain go1.23.4
+toolchain go1.25.4
 
 require (
 	github.com/apache/arrow/go/v13 v13.0.0
@@ -23,6 +23,7 @@ require (
 	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.1
 	helm.sh/helm/v3 v3.16.3
+	k8s.io/api v0.32.0
 	k8s.io/apimachinery v0.32.0
 	k8s.io/client-go v0.32.0
 )
@@ -151,7 +152,6 @@ require (
 	google.golang.org/protobuf v1.35.1 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
-	k8s.io/api v0.32.0 // indirect
 	k8s.io/apiextensions-apiserver v0.31.1 // indirect
 	k8s.io/apiserver v0.31.1 // indirect
 	k8s.io/cli-runtime v0.31.1 // indirect

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -99,7 +99,7 @@ func Apply(h Helm, verbose bool) error {
 	// RepoUpdate()
 
 	// Locate chart path
-	cp, err := client.ChartPathOptions.LocateChart(fmt.Sprintf("%s/%s", h.RepoName, h.ChartName), settings)
+	cp, err := client.LocateChart(fmt.Sprintf("%s/%s", h.RepoName, h.ChartName), settings)
 	if err != nil {
 		return err
 	}
@@ -318,7 +318,7 @@ func Upgrade(h Helm) error {
 	// RepoUpdate()
 
 	// Locate chart path
-	cp, err := client.ChartPathOptions.LocateChart(fmt.Sprintf("%s/%s", h.RepoName, h.ChartName), settings)
+	cp, err := client.LocateChart(fmt.Sprintf("%s/%s", h.RepoName, h.ChartName), settings)
 	if err != nil {
 		return err
 	}

--- a/pkg/installer/installer.go
+++ b/pkg/installer/installer.go
@@ -272,13 +272,14 @@ func promptNamespaceAndCredentials() (*ParseableInfo, error) {
 // applyParseableSecret creates and applies the Kubernetes secret
 func applyParseableSecret(ps *ParseableInfo, store ObjectStore, objectStoreConfig ObjectStoreConfig) error {
 	var secretManifest string
-	if store == LocalStore {
+	switch store {
+	case LocalStore:
 		secretManifest = getParseableSecretLocal(ps)
-	} else if store == S3Store {
+	case S3Store:
 		secretManifest = getParseableSecretS3(ps, objectStoreConfig)
-	} else if store == BlobStore {
+	case BlobStore:
 		secretManifest = getParseableSecretBlob(ps, objectStoreConfig)
-	} else if store == GcsStore {
+	case GcsStore:
 		secretManifest = getParseableSecretGcs(ps, objectStoreConfig)
 	}
 

--- a/pkg/iterator/iterator_test.go
+++ b/pkg/iterator/iterator_test.go
@@ -89,7 +89,7 @@ func TestIteratorConstruct(t *testing.T) {
 	iter := NewQueryIterator(scenario.StartTime(), scenario.EndTime(), true, scenario.QueryRunnerFunc(), scenario.HasDataFunc())
 
 	currentWindow := iter.windows[0]
-	if !(currentWindow.time == scenario.StartTime()) {
+	if currentWindow.time != scenario.StartTime() {
 		t.Fatalf("window time does not match start, expected %s, actual %s", scenario.StartTime().String(), currentWindow.time.String())
 	}
 }
@@ -202,7 +202,7 @@ func TestIteratorDescending(t *testing.T) {
 
 func checkCurrentWindowIndex(expectedValue string, currentWindow MinuteCheckPoint, t *testing.T) {
 	expectedTime, _ := time.Parse(time.RFC822Z, expectedValue)
-	if !(currentWindow.time == expectedTime) {
+	if currentWindow.time != expectedTime {
 		t.Fatalf("window time does not match start, expected %s, actual %s", expectedTime.String(), currentWindow.time.String())
 	}
 }

--- a/pkg/model/role/role.go
+++ b/pkg/model/role/role.go
@@ -65,7 +65,7 @@ func (m *Model) Valid() bool {
 	case "admin", "editor", "none":
 		return true
 	case "writer", "reader", "ingestor":
-		return !(strings.Contains(m.Stream.Value(), " ") || m.Stream.Value() == "")
+		return !strings.Contains(m.Stream.Value(), " ") && m.Stream.Value() != ""
 	}
 	return true
 }


### PR DESCRIPTION
### What i changed
- Stabilized Makefile VERSION fallback for tagless clones (just for dev purpose [will update this parallely])
- Pinned golangci-lint version and updated config to v2 format
- Removed unused tooling installs (stringer/staticcheck standalone) 
`this comes buid-in with latest version of go-lint`
- Updated Go version/toolchain for consistent builds

### Test
- Tested using the `make file` commands and working as expected in dev environment.