### PR TITLE
fix: render MODE highlight when instant query selected

### DIFF
--- a/pkg/model/promql.go
+++ b/pkg/model/promql.go
@@ -1375,12 +1375,16 @@ func renderPromqlControlsBox(dataset, step, mode string, width, height int, data
 		sLabel = lipgloss.NewStyle().Foreground(p.Ghost)
 		stepVal = lipgloss.NewStyle().Foreground(p.Ghost).Render("—")
 	}
+	modeLabel := sLabel
+	if stepHi && instant {
+		modeLabel = hi
+	}
 	lines := []string{
 		prefix(datasetHi) + dLabel.Render("DATASET"),
 		prefix(datasetHi) + val.Render(dataset),
 		"",
-		prefix(stepHi && !instant) + sLabel.Render("STEP  ") + stepVal,
-		prefix(stepHi && !instant) + sLabel.Render("MODE  ") + val.Render(mode),
+		prefix(stepHi) + sLabel.Render("STEP  ") + stepVal,
+		prefix(stepHi) + modeLabel.Render("MODE  ") + val.Render(mode),
 	}
 	body := lipgloss.NewStyle().
 		Width(innerW).


### PR DESCRIPTION
### Small fix in the promql dataset and step-mode box -

- The MODE row wasn't highlighting when instant query was selected because its style was tied to `!instant`. 
- Added a separate `modeLabel` style that shows up when instant is active. nothing major.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed PromQL controls sidebar styling to properly display active state for STEP and MODE controls when the step field is focused in instant query mode.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/parseablehq/pb/pull/98?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->