### PR TITLE
feat: refine CLI workflows for datasets, queries, auth, and help

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ The wizard asks for your server URL, auth method (username/password or API key),
 **Step 2 — Run your first query**
 
 ```bash
-pb query run "SELECT * FROM backend" --from=10m --to=now
+pb sql run "SELECT * FROM backend" --from=10m --to=now
 ```
 
 ## Commands
@@ -83,12 +83,12 @@ pb logout                                                         # remove the a
 ### SQL Query
 
 ```bash
-pb query run "SELECT * FROM backend" --from=10m --to=now
-pb query run "SELECT * FROM backend" --from=1h
-pb query run "SELECT * FROM backend" --from=2024-01-01T00:00:00Z --to=2024-01-01T01:00:00Z
-pb query run "SELECT * FROM backend" --from=1h --output json | jq .
-pb query run "SELECT * FROM backend WHERE status = 500" --from=1h --save-as=server-errors
-pb query list    # list and apply saved queries
+pb sql run "SELECT * FROM backend" --from=10m --to=now
+pb sql run "SELECT * FROM backend" --from=1h
+pb sql run "SELECT * FROM backend" --from=2024-01-01T00:00:00Z --to=2024-01-01T01:00:00Z
+pb sql run "SELECT * FROM backend" --from=1h --output json | jq .
+pb sql run "SELECT * FROM backend WHERE status = 500" --from=1h --save-as=server-errors
+pb sql list    # list and apply saved queries
 ```
 
 OTel fields with dots like `service.name` and `http.status_code` work directly in queries without manual quoting.
@@ -96,8 +96,8 @@ OTel fields with dots like `service.name` and `http.status_code` work directly i
 ### SQL Interactive Mode
 
 ```bash
-pb query run -i
-pb query run "SELECT * FROM backend" --from=1h -i
+pb sql run -i
+pb sql run "SELECT * FROM backend" --from=1h -i
 ```
 
 Panels: Query, Time Range, Table. Navigate with Tab and Shift+Tab.
@@ -105,33 +105,31 @@ Panels: Query, Time Range, Table. Navigate with Tab and Shift+Tab.
 ### PromQL Query
 
 ```bash
-pb query promql run "rate(http_requests_total[5m])" --dataset otel_metrics --from=1h --step=1m
-pb query promql run "up" --dataset otel_metrics --instant
-pb query promql run "http_requests_total" --dataset otel_metrics --output json
+pb promql run "rate(http_requests_total[5m])" --dataset otel_metrics --from=1h --step=1m
+pb promql run "up" --dataset otel_metrics --instant
+pb promql run "http_requests_total" --dataset otel_metrics --output json
 ```
 
 Explore labels and series:
 
 ```bash
-pb query promql labels --dataset otel_metrics
-pb query promql label-values job --dataset otel_metrics
-pb query promql series --match 'http_requests_total{job="api"}' --dataset otel_metrics
+pb promql labels --dataset otel_metrics
+pb promql label-values job --dataset otel_metrics
+pb promql series --match 'http_requests_total{job="api"}' --dataset otel_metrics
 ```
 
 Cardinality analysis:
 
 ```bash
-pb query promql cardinality label-names --dataset otel_metrics
-pb query promql active-queries
+pb promql cardinality label-names --dataset otel_metrics
+pb promql active-queries
 ```
 
 ### PromQL Interactive Mode
 
 ```bash
-pb query run -i --promql
-#or
-pb query promql run -i
-pb query promql run "http_requests_total" --dataset otel_metrics --from=1h -i
+pb promql run -i
+pb promql run "http_requests_total" --dataset otel_metrics --from=1h -i
 ```
 
 Panels: Dataset, Query, Time, Step, Table. Navigate with Tab and Shift+Tab. Press Space on the Step panel to toggle between range and instant mode.

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ pb sql run "SELECT * FROM backend" --from=1h
 pb sql run "SELECT * FROM backend" --from=2024-01-01T00:00:00Z --to=2024-01-01T01:00:00Z
 pb sql run "SELECT * FROM backend" --from=1h --output json | jq .
 pb sql run "SELECT * FROM backend WHERE status = 500" --from=1h --save-as=server-errors
+pb sql save "SELECT * FROM backend WHERE status = 500" --name=server-errors
 pb sql list    # list and apply saved queries
 ```
 

--- a/cmd/dataset.go
+++ b/cmd/dataset.go
@@ -17,15 +17,25 @@ package cmd
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
+	"pb/pkg/datasets"
 	internalHTTP "pb/pkg/http"
+	"pb/pkg/ui"
+	"strings"
 	"time"
 
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
 	"github.com/dustin/go-humanize"
 	"github.com/spf13/cobra"
 )
+
+const datasetTypeFlag = "type"
+
+var errDatasetTypeSelectionCanceled = errors.New("dataset type selection canceled")
 
 // DatasetStatsData is the data structure for dataset stats
 type DatasetStatsData struct {
@@ -47,8 +57,9 @@ type DatasetListItem struct {
 }
 
 func (item *DatasetListItem) Render() string {
-	render := StandardStyle.Render(item.Name)
-	return ItemOuter.Render(render)
+	bullet := SelectedStyle.Render("•")
+	name := StandardStyle.Render(item.Name)
+	return ItemOuter.Render(fmt.Sprintf("%s %s", bullet, name))
 }
 
 // DatasetRetentionData is the data structure for dataset retention
@@ -104,10 +115,11 @@ type RuleConfig struct {
 
 // AddDatasetCmd is the parent command for dataset
 var AddDatasetCmd = &cobra.Command{
-	Use:     "add dataset-name",
-	Example: "  pb dataset add backend_logs",
-	Short:   "Create a new dataset",
-	Args:    cobra.ExactArgs(1),
+	Use:          "add dataset-name",
+	Example:      "  pb dataset add backend_logs\n  pb dataset add frontend_metrics --type metrics\n  pb dataset add checkout_traces --type traces",
+	Short:        "Create a new dataset",
+	Args:         cobra.ExactArgs(1),
+	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// Capture start time
 		startTime := time.Now()
@@ -117,12 +129,31 @@ var AddDatasetCmd = &cobra.Command{
 		}()
 
 		name := args[0]
+		datasetType, err := cmd.Flags().GetString(datasetTypeFlag)
+		if err != nil {
+			cmd.Annotations["errors"] = fmt.Sprintf("Error: %s", err.Error())
+			return err
+		}
+		datasetType, err = resolveDatasetType(datasetType)
+		if err != nil {
+			if errors.Is(err, errDatasetTypeSelectionCanceled) {
+				fmt.Println("Dataset creation canceled")
+				return nil
+			}
+			cmd.Annotations["errors"] = fmt.Sprintf("Error: %s", err.Error())
+			return err
+		}
+
 		client := internalHTTP.DefaultClient(&DefaultProfile)
 		req, err := client.NewRequest("PUT", "logstream/"+name, nil)
 		if err != nil {
 			// Capture error
 			cmd.Annotations["errors"] = fmt.Sprintf("Error: %s", err.Error())
 			return err
+		}
+		req.Header.Set("X-P-Telemetry-Type", datasetType)
+		if datasetType == datasets.TypeMetrics || datasetType == datasets.TypeTraces {
+			req.Header.Set("X-P-Log-Source", "otel-"+datasetType)
 		}
 
 		resp, err := client.Client.Do(req)
@@ -136,7 +167,7 @@ var AddDatasetCmd = &cobra.Command{
 		cmd.Annotations["executionTime"] = time.Since(startTime).String()
 
 		if resp.StatusCode == 200 {
-			fmt.Printf("Created dataset %s\n", StyleBold.Render(name))
+			fmt.Printf("Created %s dataset %s\n", SelectedStyle.Render(datasetType), StyleBold.Render(name))
 		} else {
 			bytes, err := io.ReadAll(resp.Body)
 			if err != nil {
@@ -152,12 +183,151 @@ var AddDatasetCmd = &cobra.Command{
 	},
 }
 
+func init() {
+	AddDatasetCmd.Flags().String(datasetTypeFlag, "", "Dataset type (logs|metrics|traces)")
+}
+
+func resolveDatasetType(value string) (string, error) {
+	value = strings.ToLower(strings.TrimSpace(value))
+	if value == "" {
+		return promptDatasetType()
+	}
+	return validateDatasetType(value)
+}
+
+func validateDatasetType(value string) (string, error) {
+	switch value {
+	case datasets.TypeLogs, datasets.TypeMetrics, datasets.TypeTraces:
+		return value, nil
+	default:
+		return "", fmt.Errorf("invalid dataset type %q (use: logs, metrics, traces)", value)
+	}
+}
+
+func promptDatasetType() (string, error) {
+	_m, err := tea.NewProgram(newDatasetTypePicker()).Run()
+	if err != nil {
+		return "", err
+	}
+
+	m := _m.(datasetTypePicker)
+	if !m.success {
+		return "", errDatasetTypeSelectionCanceled
+	}
+	return m.choice(), nil
+}
+
+type datasetTypeOption struct {
+	value string
+}
+
+type datasetTypePicker struct {
+	options []datasetTypeOption
+	cursor  int
+	success bool
+}
+
+func newDatasetTypePicker() datasetTypePicker {
+	return datasetTypePicker{
+		options: []datasetTypeOption{
+			{value: datasets.TypeLogs},
+			{value: datasets.TypeMetrics},
+			{value: datasets.TypeTraces},
+		},
+	}
+}
+
+func (m datasetTypePicker) Init() tea.Cmd {
+	return nil
+}
+
+func (m datasetTypePicker) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "ctrl+c", "esc":
+			return m, tea.Quit
+		case "up", "k":
+			if m.cursor > 0 {
+				m.cursor--
+			}
+		case "down", "j":
+			if m.cursor < len(m.options)-1 {
+				m.cursor++
+			}
+		case "enter":
+			m.success = true
+			return m, tea.Quit
+		}
+	}
+	return m, nil
+}
+
+func (m datasetTypePicker) View() string {
+	var b strings.Builder
+
+	titleStyle := lipgloss.NewStyle().
+		Bold(true).
+		Foreground(ui.Adaptive(func(p ui.Palette) lipgloss.Color { return p.Accent }))
+	labelStyle := lipgloss.NewStyle().
+		Bold(true).
+		Foreground(ui.Adaptive(func(p ui.Palette) lipgloss.Color { return p.Mute }))
+	selectedStyle := lipgloss.NewStyle().
+		Bold(true).
+		Foreground(ui.Adaptive(func(p ui.Palette) lipgloss.Color { return p.Active }))
+	normalStyle := lipgloss.NewStyle().
+		Foreground(ui.Adaptive(func(p ui.Palette) lipgloss.Color { return p.Body }))
+	dimStyle := lipgloss.NewStyle().
+		Foreground(ui.Adaptive(func(p ui.Palette) lipgloss.Color { return p.Faint }))
+	keyStyle := lipgloss.NewStyle().
+		Bold(true).
+		Foreground(ui.Adaptive(func(p ui.Palette) lipgloss.Color { return p.Accent }))
+	railStyle := lipgloss.NewStyle().
+		Background(ui.Adaptive(func(p ui.Palette) lipgloss.Color { return p.Active }))
+
+	b.WriteString(titleStyle.Render("CREATE DATASET"))
+	b.WriteString("\n\n")
+	b.WriteString(labelStyle.Render("DATASET TYPE"))
+	b.WriteString("\n\n")
+
+	for idx, option := range m.options {
+		if idx == m.cursor {
+			b.WriteString(railStyle.Render(" "))
+			b.WriteString(" ")
+			b.WriteString(selectedStyle.Render("❯ " + option.value))
+		} else {
+			b.WriteString("    ")
+			b.WriteString(normalStyle.Render(option.value))
+		}
+		b.WriteString("\n")
+	}
+
+	b.WriteString("\n")
+	b.WriteString("  ")
+	b.WriteString(keyStyle.Render("<↑↓>"))
+	b.WriteString(dimStyle.Render(" navigate    "))
+	b.WriteString(keyStyle.Render("<enter>"))
+	b.WriteString(dimStyle.Render(" select    "))
+	b.WriteString(keyStyle.Render("<esc>"))
+	b.WriteString(dimStyle.Render(" cancel"))
+	return b.String()
+}
+
+func (m datasetTypePicker) choice() string {
+	if len(m.options) == 0 {
+		return ""
+	}
+	return m.options[m.cursor].value
+}
+
 // StatDatasetCmd is the stat command for dataset
 var StatDatasetCmd = &cobra.Command{
-	Use:     "info dataset-name",
-	Example: "  pb dataset info backend_logs",
-	Short:   "Get statistics for a dataset",
-	Args:    cobra.ExactArgs(1),
+	Use:          "info dataset-name",
+	Aliases:      []string{"stat"},
+	Example:      "  pb dataset info backend_logs",
+	Short:        "Get statistics for a dataset",
+	Args:         cobra.ExactArgs(1),
+	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// Capture start time
 		startTime := time.Now()
@@ -168,6 +338,14 @@ var StatDatasetCmd = &cobra.Command{
 
 		name := args[0]
 		client := internalHTTP.DefaultClient(&DefaultProfile)
+
+		// Fetch dataset type first so a missing dataset fails clearly instead
+		// of being rendered as zero stats with an unknown type.
+		datasetType, err := fetchInfo(&client, name)
+		if err != nil {
+			cmd.Annotations["errors"] = fmt.Sprintf("Error: %s", err.Error())
+			return err
+		}
 
 		// Fetch stats data
 		stats, err := fetchStats(&client, name)
@@ -195,14 +373,6 @@ var StatDatasetCmd = &cobra.Command{
 
 		// Fetch alerts data
 		alertsData, err := fetchAlerts(&client, name)
-		if err != nil {
-			// Capture error
-			cmd.Annotations["errors"] = fmt.Sprintf("Error: %s", err.Error())
-			return err
-		}
-
-		// Fetch dataset type
-		datasetType, err := fetchInfo(&client, name)
 		if err != nil {
 			// Capture error
 			cmd.Annotations["errors"] = fmt.Sprintf("Error: %s", err.Error())
@@ -238,27 +408,27 @@ var StatDatasetCmd = &cobra.Command{
 			isAlertsSet := len(alertsData.Alerts) > 0
 
 			// Render the info section with consistent alignment
-			fmt.Println(StyleBold.Render("\nInfo:"))
+			fmt.Println(SelectedStyle.Render("\nInfo:"))
 			fmt.Printf("  %-18s %d\n", "Event Count:", ingestionCount)
 			fmt.Printf("  %-18s %s\n", "Ingestion Size:", humanize.Bytes(uint64(ingestionSize)))
 			fmt.Printf("  %-18s %s\n", "Storage Size:", humanize.Bytes(uint64(storageSize)))
 			fmt.Printf("  %-18s %.2f%s\n", "Compression Ratio:", compressionRatio, "%")
-			fmt.Printf("  %-18s %s\n", "Dataset Type:", datasetType)
+			fmt.Printf("  %-18s %s\n", "Dataset Type:", SelectedStyle.Render(datasetType))
 			fmt.Println()
 
 			if isRetentionSet {
-				fmt.Println(StyleBold.Render("Retention:"))
+				fmt.Println(SelectedStyle.Render("Retention:"))
 				for _, item := range retention {
 					fmt.Printf("  Action:    %s\n", StyleBold.Render(item.Action))
 					fmt.Printf("  Duration:  %s\n", StyleBold.Render(item.Duration))
 					fmt.Println()
 				}
 			} else {
-				fmt.Println(StyleBold.Render("No retention period set on dataset\n"))
+				fmt.Println(SelectedStyle.Render("No retention period set on dataset\n"))
 			}
 
 			if isAlertsSet {
-				fmt.Println(StyleBold.Render("Alerts:"))
+				fmt.Println(SelectedStyle.Render("Alerts:"))
 				for _, alert := range alertsData.Alerts {
 					fmt.Printf("  Alert:   %s\n", StyleBold.Render(alert.Name))
 					ruleFmt := fmt.Sprintf(
@@ -276,7 +446,7 @@ var StatDatasetCmd = &cobra.Command{
 					fmt.Print("\n\n")
 				}
 			} else {
-				fmt.Println(StyleBold.Render("No alerts set on dataset\n"))
+				fmt.Println(SelectedStyle.Render("No alerts set on dataset\n"))
 			}
 		}
 
@@ -289,11 +459,12 @@ func init() {
 }
 
 var RemoveDatasetCmd = &cobra.Command{
-	Use:     "remove dataset-name",
-	Aliases: []string{"rm"},
-	Example: " pb dataset remove backend_logs",
-	Short:   "Delete a dataset",
-	Args:    cobra.ExactArgs(1),
+	Use:          "remove dataset-name",
+	Aliases:      []string{"rm"},
+	Example:      " pb dataset remove backend_logs\n pb dataset remove backend_logs --type logs",
+	Short:        "Delete a dataset",
+	Args:         cobra.ExactArgs(1),
+	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// Capture start time
 		startTime := time.Now()
@@ -304,6 +475,30 @@ var RemoveDatasetCmd = &cobra.Command{
 
 		name := args[0]
 		client := internalHTTP.DefaultClient(&DefaultProfile)
+		expectedType, err := cmd.Flags().GetString(datasetTypeFlag)
+		if err != nil {
+			cmd.Annotations["errors"] = fmt.Sprintf("Error: %s", err.Error())
+			return err
+		}
+		expectedType = strings.ToLower(strings.TrimSpace(expectedType))
+		if expectedType != "" {
+			expectedType, err = validateDatasetType(expectedType)
+			if err != nil {
+				cmd.Annotations["errors"] = fmt.Sprintf("Error: %s", err.Error())
+				return err
+			}
+
+			actualType, err := fetchInfo(&client, name)
+			if err != nil {
+				cmd.Annotations["errors"] = fmt.Sprintf("Error: %s", err.Error())
+				return err
+			}
+			if err := ensureDatasetType(name, actualType, expectedType); err != nil {
+				cmd.Annotations["errors"] = fmt.Sprintf("Error: %s", err.Error())
+				return err
+			}
+		}
+
 		req, err := client.NewRequest("DELETE", "logstream/"+name, nil)
 		if err != nil {
 			// Capture error
@@ -338,11 +533,24 @@ var RemoveDatasetCmd = &cobra.Command{
 	},
 }
 
+func ensureDatasetType(name, actualType, expectedType string) error {
+	if actualType != expectedType {
+		return fmt.Errorf("dataset %q is %s, not %s", name, actualType, expectedType)
+	}
+	return nil
+}
+
+func init() {
+	RemoveDatasetCmd.Flags().String(datasetTypeFlag, "", "Only remove if dataset type matches (logs|metrics|traces)")
+}
+
 // ListDatasetCmd is the list command for datasets
 var ListDatasetCmd = &cobra.Command{
-	Use:     "list",
-	Example: "  pb dataset list",
-	Short:   "List all datasets",
+	Use:          "list",
+	Aliases:      []string{"ls"},
+	Example:      "  pb dataset list",
+	Short:        "List all datasets",
+	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, _ []string) error {
 		// Capture start time
 		startTime := time.Now()
@@ -351,40 +559,26 @@ var ListDatasetCmd = &cobra.Command{
 			cmd.Annotations["executionTime"] = time.Since(startTime).String()
 		}()
 
-		client := internalHTTP.DefaultClient(&DefaultProfile)
-		req, err := client.NewRequest("GET", "logstream", nil)
+		items, err := datasets.FetchHomeDatasets(DefaultProfile)
 		if err != nil {
-			// Capture error
 			cmd.Annotations["errors"] = fmt.Sprintf("Error: %s", err.Error())
 			return err
 		}
 
-		resp, err := client.Client.Do(req)
-		if err != nil {
-			// Capture error
-			cmd.Annotations["errors"] = fmt.Sprintf("Error: %s", err.Error())
-			return err
-		}
-
-		var datasets []DatasetListItem
-		if resp.StatusCode == 200 {
-			bytes, err := io.ReadAll(resp.Body)
+		output, _ := cmd.Flags().GetString("output")
+		if output == "json" {
+			jsonData, err := json.MarshalIndent(items, "", "  ")
 			if err != nil {
 				cmd.Annotations["errors"] = fmt.Sprintf("Error: %s", err.Error())
 				return err
 			}
-			if err := json.Unmarshal(bytes, &datasets); err != nil {
-				cmd.Annotations["errors"] = fmt.Sprintf("Error: %s", err.Error())
-				return err
-			}
-
-			for _, dataset := range datasets {
-				fmt.Println(dataset.Render())
-			}
-		} else {
-			fmt.Printf("Failed to fetch datasets. Status Code: %s\n", resp.Status)
+			fmt.Println(string(jsonData))
+			return nil
 		}
 
+		for _, dataset := range items {
+			fmt.Println((&DatasetListItem{Name: dataset.Title}).Render())
+		}
 		return nil
 	},
 }
@@ -503,7 +697,8 @@ func fetchInfo(client *internalHTTP.HTTPClient, name string) (datasetType string
 	case http.StatusOK:
 		// Define a struct to parse the response
 		var response struct {
-			StreamType string `json:"stream_type"`
+			StreamType    string `json:"streamType"`
+			TelemetryType string `json:"telemetryType"`
 		}
 
 		// Unmarshal JSON into the struct
@@ -511,11 +706,12 @@ func fetchInfo(client *internalHTTP.HTTPClient, name string) (datasetType string
 			return "", fmt.Errorf("failed to unmarshal response: %w", err)
 		}
 
-		// Return the extracted stream_type
+		if response.TelemetryType != "" {
+			return response.TelemetryType, nil
+		}
 		return response.StreamType, nil
 	case http.StatusNotFound:
-		// endpoint not available on this server version or stream has no type info
-		return "unknown", nil
+		return "", fmt.Errorf("dataset %q not found", name)
 	default:
 		// Handle non-200 responses
 		return "", fmt.Errorf("Request Failed\nStatus Code: %d\nResponse: %s\n", resp.StatusCode, string(bytes))

--- a/cmd/dataset_test.go
+++ b/cmd/dataset_test.go
@@ -1,0 +1,70 @@
+package cmd
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"pb/pkg/config"
+	internalHTTP "pb/pkg/http"
+	"testing"
+)
+
+func TestFetchInfoUsesTelemetryType(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got, want := r.URL.Path, "/api/v1/logstream/fly_logs/info"; got != want {
+			t.Fatalf("path mismatch: want %s got %s", want, got)
+		}
+		fmt.Fprint(w, `{"streamType":"UserDefined","telemetryType":"logs"}`)
+	}))
+	defer server.Close()
+
+	client := internalHTTP.DefaultClient(&config.Profile{URL: server.URL})
+	got, err := fetchInfo(&client, "fly_logs")
+	if err != nil {
+		t.Fatalf("fetchInfo returned error: %v", err)
+	}
+	if got != "logs" {
+		t.Fatalf("dataset type mismatch: want logs got %s", got)
+	}
+}
+
+func TestValidateDatasetTypeAcceptsSupportedTypes(t *testing.T) {
+	for _, datasetType := range []string{"logs", "metrics", "traces"} {
+		got, err := validateDatasetType(datasetType)
+		if err != nil {
+			t.Fatalf("expected %q to be valid: %v", datasetType, err)
+		}
+		if got != datasetType {
+			t.Fatalf("got %q, want %q", got, datasetType)
+		}
+	}
+}
+
+func TestValidateDatasetTypeRejectsUnsupportedType(t *testing.T) {
+	if _, err := validateDatasetType("events"); err == nil {
+		t.Fatal("expected unsupported dataset type to fail")
+	}
+}
+
+func TestEnsureDatasetTypeAcceptsMatchingType(t *testing.T) {
+	if err := ensureDatasetType("server_logs", "logs", "logs"); err != nil {
+		t.Fatalf("expected matching dataset type to pass: %v", err)
+	}
+}
+
+func TestEnsureDatasetTypeRejectsMismatchedType(t *testing.T) {
+	if err := ensureDatasetType("server_logs", "metrics", "logs"); err == nil {
+		t.Fatal("expected mismatched dataset type to fail")
+	}
+}
+
+func TestFetchInfoReturnsNotFoundError(t *testing.T) {
+	server := httptest.NewServer(http.NotFoundHandler())
+	defer server.Close()
+
+	client := internalHTTP.DefaultClient(&config.Profile{URL: server.URL})
+	_, err := fetchInfo(&client, "missing")
+	if err == nil {
+		t.Fatal("expected not found error")
+	}
+}

--- a/cmd/logout.go
+++ b/cmd/logout.go
@@ -16,9 +16,14 @@
 package cmd
 
 import (
+	"bufio"
 	"fmt"
+	"os"
 	"pb/pkg/config"
+	"pb/pkg/model/defaultprofile"
+	"strings"
 
+	tea "github.com/charmbracelet/bubbletea"
 	"github.com/spf13/cobra"
 )
 
@@ -34,18 +39,102 @@ var LogoutCmd = &cobra.Command{
 		}
 
 		profileName := fileConfig.DefaultProfile
-		if _, exists := fileConfig.Profiles[profileName]; !exists {
-			return fmt.Errorf("no active profile found")
+		activeProfile, exists := fileConfig.Profiles[profileName]
+		if !exists || profileName == "" {
+			if len(fileConfig.Profiles) == 0 {
+				return fmt.Errorf("no active profile found")
+			}
+			selectedProfile, err := selectLogoutProfile(fileConfig.Profiles)
+			if err != nil {
+				return err
+			}
+			if selectedProfile == "" {
+				fmt.Println("Logout canceled")
+				return nil
+			}
+			profileName = selectedProfile
+			activeProfile = fileConfig.Profiles[profileName]
+		}
+
+		if !confirmLogout(profileName, activeProfile.URL) {
+			fmt.Println("Logout canceled")
+			return nil
 		}
 
 		delete(fileConfig.Profiles, profileName)
-		fileConfig.DefaultProfile = ""
+		newDefaultProfile := ""
+		switch len(fileConfig.Profiles) {
+		case 0:
+			fileConfig.DefaultProfile = ""
+		case 1:
+			for name := range fileConfig.Profiles {
+				fileConfig.DefaultProfile = name
+				newDefaultProfile = name
+			}
+		default:
+			fmt.Println("Select a new default profile:")
+			_m, err := tea.NewProgram(defaultprofile.New(fileConfig.Profiles)).Run()
+			if err != nil {
+				return fmt.Errorf("error selecting new default profile: %w", err)
+			}
+			m := _m.(defaultprofile.Model)
+			if m.Success {
+				fileConfig.DefaultProfile = m.Choice
+				newDefaultProfile = m.Choice
+			} else {
+				fileConfig.DefaultProfile = ""
+			}
+		}
 
 		if err := config.WriteConfigToFile(fileConfig); err != nil {
 			return fmt.Errorf("failed to update config: %w", err)
 		}
 
 		fmt.Printf("Logged out and removed profile '%s'\n", profileName)
+		if newDefaultProfile != "" {
+			fmt.Printf("'%s' is now set as the default profile\n", newDefaultProfile)
+		}
 		return nil
 	},
+}
+
+func selectLogoutProfile(profiles map[string]config.Profile) (string, error) {
+	if len(profiles) == 1 {
+		for name := range profiles {
+			return name, nil
+		}
+	}
+
+	fmt.Println("Select profile to logout:")
+	_m, err := tea.NewProgram(defaultprofile.New(profiles)).Run()
+	if err != nil {
+		return "", fmt.Errorf("error selecting profile to logout: %w", err)
+	}
+	m := _m.(defaultprofile.Model)
+	if !m.Success {
+		return "", nil
+	}
+	return m.Choice, nil
+}
+
+func confirmLogout(profileName, profileURL string) bool {
+	fmt.Printf(
+		"Logout from profile %s %s?\n",
+		SelectedStyle.Render("'"+profileName+"'"),
+		StandardStyleAlt.Render("("+profileURL+")"),
+	)
+	fmt.Println(StandardStyleAlt.Render("This will remove the saved URL and credentials from config"))
+	fmt.Printf("%s ", SelectedStyle.Render("Continue? [y/N]:"))
+
+	response, err := bufio.NewReader(os.Stdin).ReadString('\n')
+	if err != nil {
+		return false
+	}
+
+	switch strings.ToLower(strings.TrimSpace(response)) {
+	case "y", "yes":
+		return true
+	default:
+		return false
+	}
 }

--- a/cmd/profile.go
+++ b/cmd/profile.go
@@ -329,6 +329,7 @@ var UpdateProfileCmd = &cobra.Command{
 
 var ListProfileCmd = &cobra.Command{
 	Use:     "list profiles",
+	Aliases: []string{"ls"},
 	Short:   "List all added profiles",
 	Example: "  pb profile list",
 	RunE: func(cmd *cobra.Command, _ []string) error {

--- a/cmd/promql.go
+++ b/cmd/promql.go
@@ -16,6 +16,7 @@
 package cmd
 
 import (
+	"bytes"
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
@@ -36,12 +37,15 @@ const defaultMetricsStream = "select-dataset"
 
 // PromqlCmd is the parent command for all PromQL operations.
 var PromqlCmd = &cobra.Command{
-	Use:   "promql",
-	Short: "PromQL queries and metrics exploration",
-	Long:  "\nRun PromQL queries and explore metrics stored in a Parseable metrics stream.",
+	Use:     "promql",
+	Short:   "PromQL queries and metrics exploration",
+	Long:    "\nRun PromQL queries and explore metrics stored in a Parseable metrics stream.",
+	Example: "  pb promql run -i\n  pb promql run \"http_requests_total\" --dataset otel_metrics --from=1h -i",
 }
 
 func init() {
+	PromqlCmd.SetHelpFunc(renderPromqlHelp)
+
 	// query execution
 	PromqlCmd.AddCommand(promqlRunCmd)
 
@@ -117,6 +121,58 @@ func init() {
 	promqlTSDBCmd.Flags().StringP("output", "o", "text", "Output format: text or json")
 }
 
+func renderPromqlHelp(cmd *cobra.Command, _ []string) {
+	out := cmd.OutOrStdout()
+
+	if cmd.Long != "" {
+		fmt.Fprintln(out, cmd.Long)
+		fmt.Fprintln(out)
+	}
+
+	fmt.Fprintln(out, "Usage:")
+	fmt.Fprintf(out, "  %s\n", cmd.UseLine())
+	fmt.Fprintln(out)
+
+	if cmd.Example != "" {
+		fmt.Fprintln(out, "Examples:")
+		fmt.Fprintln(out, cmd.Example)
+		fmt.Fprintln(out)
+	}
+
+	order := []string{"run", "labels", "label-values", "series", "cardinality", "tsdb", "active-queries"}
+	commandsByName := make(map[string]*cobra.Command, len(cmd.Commands()))
+	for _, child := range cmd.Commands() {
+		commandsByName[child.Name()] = child
+	}
+
+	fmt.Fprintln(out, "Available Commands:")
+	width := 0
+	for _, name := range order {
+		if len(name) > width {
+			width = len(name)
+		}
+	}
+	for _, name := range order {
+		child, ok := commandsByName[name]
+		if !ok || (!child.IsAvailableCommand() && child.Name() != "help") {
+			continue
+		}
+		fmt.Fprintf(out, "  %-*s %s\n", width, child.Name(), child.Short)
+	}
+	fmt.Fprintln(out)
+
+	if cmd.HasAvailableLocalFlags() {
+		fmt.Fprintln(out, "Flags:")
+		var flags bytes.Buffer
+		cmd.LocalFlags().SetOutput(&flags)
+		cmd.LocalFlags().PrintDefaults()
+		fmt.Fprint(out, flags.String())
+		fmt.Fprintln(out)
+	}
+
+	fmt.Fprintf(out, "Use \"%s [command] --help\" for more information about a command.\n", cmd.CommandPath())
+}
+
 // ---------------------------------------------------------------------------
 // Shared helpers
 // ---------------------------------------------------------------------------
@@ -185,9 +241,9 @@ var promqlRunCmd = &cobra.Command{
 	Use:   "run [expr]",
 	Short: "Run a PromQL query (range or instant)",
 	Long:  "\nEvaluate a PromQL expression against a Parseable metrics stream.\nDefaults to range query. Use --instant for point-in-time evaluation.",
-	Example: "  pb query promql run \"http_requests_total\" --dataset otel_metrics --from 1h\n" +
-		"  pb query promql run \"rate(http_requests_total[5m])\" --dataset otel_metrics --from 1h --step 1m\n" +
-		"  pb query promql run \"up\" --dataset otel_metrics --instant -o json",
+	Example: "  pb promql run \"http_requests_total\" --dataset otel_metrics --from 1h\n" +
+		"  pb promql run \"rate(http_requests_total[5m])\" --dataset otel_metrics --from 1h --step 1m\n" +
+		"  pb promql run \"up\" --dataset otel_metrics --instant -o json",
 	Args:    cobra.MaximumNArgs(1),
 	PreRunE: PreRunDefaultProfile,
 	RunE:    runPromqlQuery,
@@ -223,6 +279,7 @@ func runPromqlQuery(cmd *cobra.Command, args []string) error {
 	outputFmt, _ := cmd.Flags().GetString("output")
 	instant, _ := cmd.Flags().GetBool("instant")
 	interactive, _ := cmd.Flags().GetBool("interactive")
+	fromStr = promqlInteractiveFromDefault(fromStr, interactive, cmd.Flags().Changed("from"))
 
 	toTime, err := parseTimeStr(toStr)
 	if err != nil {
@@ -242,7 +299,7 @@ func runPromqlQuery(cmd *cobra.Command, args []string) error {
 
 	if strings.TrimSpace(expr) == "" {
 		fmt.Println("Please enter a PromQL expression")
-		fmt.Printf("Example:\n  pb query promql run \"http_requests_total\" --dataset otel_metrics\n  pb query promql run -i\n")
+		fmt.Printf("Example:\n  pb promql run \"http_requests_total\" --dataset otel_metrics\n  pb promql run -i\n")
 		return nil
 	}
 
@@ -308,6 +365,13 @@ func runPromqlQuery(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
+func promqlInteractiveFromDefault(from string, interactive, fromChanged bool) string {
+	if interactive && !fromChanged {
+		return "10m"
+	}
+	return from
+}
+
 // ---------------------------------------------------------------------------
 // 2. labels — list all label names
 // ---------------------------------------------------------------------------
@@ -315,7 +379,7 @@ func runPromqlQuery(cmd *cobra.Command, args []string) error {
 var promqlLabelsCmd = &cobra.Command{
 	Use:     "labels",
 	Short:   "List all label names in a metrics stream",
-	Example: "  pb query promql labels --stream otel_metrics",
+	Example: "  pb promql labels --dataset otel_metrics",
 	Args:    cobra.NoArgs,
 	PreRunE: PreRunDefaultProfile,
 	RunE: func(cmd *cobra.Command, _ []string) error {
@@ -363,7 +427,7 @@ var promqlLabelsCmd = &cobra.Command{
 var promqlLabelValuesCmd = &cobra.Command{
 	Use:     "label-values [label_name]",
 	Short:   "List distinct values for a label",
-	Example: "  pb query promql label-values job --stream otel_metrics\n  pb query promql label-values __name__ --stream otel_metrics",
+	Example: "  pb promql label-values job --dataset otel_metrics\n  pb promql label-values __name__ --dataset otel_metrics",
 	Args:    cobra.ExactArgs(1),
 	PreRunE: PreRunDefaultProfile,
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -412,7 +476,7 @@ var promqlLabelValuesCmd = &cobra.Command{
 var promqlSeriesCmd = &cobra.Command{
 	Use:     "series",
 	Short:   "Find time series matching a label selector",
-	Example: "  pb query promql series --match 'http_requests_total' --stream otel_metrics\n  pb query promql series --match '{job=\"api\"}' --stream otel_metrics",
+	Example: "  pb promql series --match 'http_requests_total' --dataset otel_metrics\n  pb promql series --match '{job=\"api\"}' --dataset otel_metrics",
 	Args:    cobra.NoArgs,
 	PreRunE: PreRunDefaultProfile,
 	RunE: func(cmd *cobra.Command, _ []string) error {
@@ -480,7 +544,7 @@ type cardinalityEntry struct {
 var promqlCardinalityLabelNamesCmd = &cobra.Command{
 	Use:     "label-names",
 	Short:   "Labels with the highest number of distinct values",
-	Example: "  pb query promql cardinality label-names --stream otel_metrics --limit 20",
+	Example: "  pb promql cardinality label-names --dataset otel_metrics --limit 20",
 	Args:    cobra.NoArgs,
 	PreRunE: PreRunDefaultProfile,
 	RunE: func(cmd *cobra.Command, _ []string) error {
@@ -532,7 +596,7 @@ var promqlCardinalityLabelNamesCmd = &cobra.Command{
 var promqlCardinalityLabelValuesCmd = &cobra.Command{
 	Use:     "label-values",
 	Short:   "Series count per value for a specific label",
-	Example: "  pb query promql cardinality label-values --label job --stream otel_metrics",
+	Example: "  pb promql cardinality label-values --label job --dataset otel_metrics",
 	Args:    cobra.NoArgs,
 	PreRunE: PreRunDefaultProfile,
 	RunE: func(cmd *cobra.Command, _ []string) error {
@@ -584,7 +648,7 @@ var promqlCardinalityLabelValuesCmd = &cobra.Command{
 var promqlCardinalityActiveSeriesCmd = &cobra.Command{
 	Use:     "active-series",
 	Short:   "List currently active series",
-	Example: "  pb query promql cardinality active-series --stream otel_metrics --selector '{job=\"api\"}'",
+	Example: "  pb promql cardinality active-series --dataset otel_metrics --selector '{job=\"api\"}'",
 	Args:    cobra.NoArgs,
 	PreRunE: PreRunDefaultProfile,
 	RunE: func(cmd *cobra.Command, _ []string) error {
@@ -640,8 +704,9 @@ var promqlCardinalityActiveSeriesCmd = &cobra.Command{
 
 var promqlActiveQueriesCmd = &cobra.Command{
 	Use:     "active-queries",
+	Aliases: []string{"ps"},
 	Short:   "Show currently executing PromQL queries",
-	Example: "  pb query promql active-queries",
+	Example: "  pb promql active-queries",
 	Args:    cobra.NoArgs,
 	PreRunE: PreRunDefaultProfile,
 	RunE: func(_ *cobra.Command, _ []string) error {
@@ -691,7 +756,7 @@ var promqlActiveQueriesCmd = &cobra.Command{
 var promqlTSDBCmd = &cobra.Command{
 	Use:     "tsdb",
 	Short:   "Show TSDB statistics for a metrics stream",
-	Example: "  pb query promql tsdb --stream otel_metrics\n  pb query promql tsdb --stream otel_metrics --top 20 --focus-label job",
+	Example: "  pb promql tsdb --dataset otel_metrics\n  pb promql tsdb --dataset otel_metrics --top 20 --focus-label job",
 	Args:    cobra.NoArgs,
 	PreRunE: PreRunDefaultProfile,
 	RunE: func(cmd *cobra.Command, _ []string) error {

--- a/cmd/promql_test.go
+++ b/cmd/promql_test.go
@@ -1,0 +1,24 @@
+package cmd
+
+import "testing"
+
+func TestPromqlInteractiveFromDefaultUsesTenMinutes(t *testing.T) {
+	got := promqlInteractiveFromDefault("5m", true, false)
+	if got != "10m" {
+		t.Fatalf("got %q, want 10m", got)
+	}
+}
+
+func TestPromqlInteractiveFromDefaultKeepsExplicitFrom(t *testing.T) {
+	got := promqlInteractiveFromDefault("1h", true, true)
+	if got != "1h" {
+		t.Fatalf("got %q, want 1h", got)
+	}
+}
+
+func TestPromqlInteractiveFromDefaultKeepsNonInteractiveDefault(t *testing.T) {
+	got := promqlInteractiveFromDefault("5m", false, false)
+	if got != "5m" {
+		t.Fatalf("got %q, want 5m", got)
+	}
+}

--- a/cmd/query.go
+++ b/cmd/query.go
@@ -16,6 +16,7 @@
 package cmd
 
 import (
+	"bufio"
 	"bytes"
 	"encoding/json"
 	"fmt"
@@ -207,20 +208,55 @@ func startSpinner() func() {
 	}
 }
 
-// fromClauseRe matches an unquoted identifier after FROM or JOIN.
-var fromClauseRe = regexp.MustCompile(`(?i)(\b(?:from|join)\s+)([a-zA-Z_][a-zA-Z0-9_-]*)`)
-
-// quoteStreamNames wraps stream names containing hyphens in double quotes so
-// DataFusion does not treat them as subtraction (nginx-logs → "nginx-logs").
-// Already-quoted identifiers are left untouched.
+// quoteStreamNames wraps table names that are not plain SQL identifiers in
+// double quotes so DataFusion does not treat names like nginx-logs as an
+// expression. Already-quoted identifiers and the interactive dataset
+// placeholder are left untouched.
 func quoteStreamNames(query string) string {
-	return fromClauseRe.ReplaceAllStringFunc(query, func(match string) string {
-		m := fromClauseRe.FindStringSubmatch(match)
-		if len(m) < 3 || !strings.Contains(m[2], "-") {
-			return match
+	var result strings.Builder
+	i, n := 0, len(query)
+	for i < n {
+		switch query[i] {
+		case '\'':
+			i = copySQLStringLiteral(&result, query, i)
+		case '"':
+			i = copySQLQuotedIdentifier(&result, query, i)
+		default:
+			if isSQLTableClauseAt(query, i) {
+				j := i + sqlTableClauseLen(query, i)
+				result.WriteString(query[i:j])
+				i = j
+
+				for i < n && isSQLSpace(query[i]) {
+					result.WriteByte(query[i])
+					i++
+				}
+				if i >= n {
+					continue
+				}
+				if query[i] == '"' || query[i] == '\'' || query[i] == '(' {
+					continue
+				}
+
+				start := i
+				for i < n && !isSQLTableTokenEnd(query[i]) {
+					i++
+				}
+				tableName := query[start:i]
+				if shouldQuoteSQLTableName(tableName) {
+					result.WriteByte('"')
+					result.WriteString(strings.ReplaceAll(tableName, `"`, `""`))
+					result.WriteByte('"')
+				} else {
+					result.WriteString(tableName)
+				}
+				continue
+			}
+			result.WriteByte(query[i])
+			i++
 		}
-		return m[1] + `"` + m[2] + `"`
-	})
+	}
+	return result.String()
 }
 
 // quoteFieldsWithDots wraps unquoted field identifiers that DataFusion would
@@ -348,6 +384,89 @@ func identChar(c byte) bool {
 	return identStart(c) || (c >= '0' && c <= '9')
 }
 
+func copySQLStringLiteral(result *strings.Builder, query string, start int) int {
+	result.WriteByte(query[start])
+	i := start + 1
+	for i < len(query) {
+		c := query[i]
+		result.WriteByte(c)
+		i++
+		if c == '\'' {
+			if i < len(query) && query[i] == '\'' {
+				result.WriteByte(query[i])
+				i++
+				continue
+			}
+			break
+		}
+	}
+	return i
+}
+
+func copySQLQuotedIdentifier(result *strings.Builder, query string, start int) int {
+	result.WriteByte(query[start])
+	i := start + 1
+	for i < len(query) {
+		c := query[i]
+		result.WriteByte(c)
+		i++
+		if c == '"' {
+			if i < len(query) && query[i] == '"' {
+				result.WriteByte(query[i])
+				i++
+				continue
+			}
+			break
+		}
+	}
+	return i
+}
+
+func isSQLTableClauseAt(query string, idx int) bool {
+	return isSQLKeywordAt(query, idx, "from") || isSQLKeywordAt(query, idx, "join")
+}
+
+func sqlTableClauseLen(query string, idx int) int {
+	if isSQLKeywordAt(query, idx, "from") {
+		return len("from")
+	}
+	return len("join")
+}
+
+func isSQLKeywordAt(query string, idx int, keyword string) bool {
+	if idx+len(keyword) > len(query) || !strings.EqualFold(query[idx:idx+len(keyword)], keyword) {
+		return false
+	}
+	if idx > 0 && identChar(query[idx-1]) {
+		return false
+	}
+	next := idx + len(keyword)
+	return next >= len(query) || !identChar(query[next])
+}
+
+func isSQLSpace(c byte) bool {
+	return c == ' ' || c == '\t' || c == '\n' || c == '\r'
+}
+
+func isSQLTableTokenEnd(c byte) bool {
+	return isSQLSpace(c) || c == ',' || c == ';' || c == '(' || c == ')'
+}
+
+func shouldQuoteSQLTableName(tableName string) bool {
+	if tableName == "" || strings.EqualFold(tableName, "dataset") {
+		return false
+	}
+	if !identStart(tableName[0]) {
+		return true
+	}
+	for i := 1; i < len(tableName); i++ {
+		if !identChar(tableName[i]) {
+			return true
+		}
+	}
+	return false
+}
+
 var QueryCmd = query
 
 var SaveSQLCmd = &cobra.Command{
@@ -436,7 +555,11 @@ func ensureDefaultLimit(query string) string {
 		trimmed = strings.TrimSpace(strings.TrimSuffix(trimmed, ";"))
 		suffix = ";"
 	}
-	return trimmed + " LIMIT 500" + suffix
+	separator := " "
+	if endsInLineComment(trimmed) {
+		separator = "\n"
+	}
+	return trimmed + separator + "LIMIT 500" + suffix
 }
 
 func hasTopLevelLimit(query string) bool {
@@ -465,6 +588,28 @@ func hasTopLevelLimit(query string) bool {
 				}
 				i++
 			}
+		case '-':
+			if i+1 < len(query) && query[i+1] == '-' {
+				i += 2
+				for i < len(query) && query[i] != '\n' {
+					i++
+				}
+				continue
+			}
+			i++
+		case '/':
+			if i+1 < len(query) && query[i+1] == '*' {
+				i += 2
+				for i+1 < len(query) {
+					if query[i] == '*' && query[i+1] == '/' {
+						i += 2
+						break
+					}
+					i++
+				}
+				continue
+			}
+			i++
 		case '(':
 			depth++
 			i++
@@ -495,6 +640,68 @@ func isLimitTokenAt(query string, idx int) bool {
 	return next >= len(query) || !identChar(query[next])
 }
 
+func endsInLineComment(query string) bool {
+	inSingleQuote := false
+	inDoubleQuote := false
+	inBlockComment := false
+	lineCommentStart := -1
+
+	for i := 0; i < len(query); i++ {
+		if inSingleQuote {
+			if query[i] == '\'' {
+				if i+1 < len(query) && query[i+1] == '\'' {
+					i++
+					continue
+				}
+				inSingleQuote = false
+			}
+			continue
+		}
+		if inDoubleQuote {
+			if query[i] == '"' {
+				if i+1 < len(query) && query[i+1] == '"' {
+					i++
+					continue
+				}
+				inDoubleQuote = false
+			}
+			continue
+		}
+		if inBlockComment {
+			if query[i] == '*' && i+1 < len(query) && query[i+1] == '/' {
+				inBlockComment = false
+				i++
+			}
+			continue
+		}
+
+		switch query[i] {
+		case '\'':
+			inSingleQuote = true
+		case '"':
+			inDoubleQuote = true
+		case '-':
+			if i+1 < len(query) && query[i+1] == '-' {
+				lineCommentStart = i
+				i++
+			}
+		case '/':
+			if i+1 < len(query) && query[i+1] == '*' {
+				inBlockComment = true
+				i++
+			}
+		case '\n', '\r':
+			lineCommentStart = -1
+		}
+	}
+	if lineCommentStart < 0 {
+		return false
+	}
+	return strings.TrimSpace(query[lineCommentStart+2:]) != ""
+}
+
+const queryErrorPreviewLimit = 64 * 1024
+
 func fetchData(client *internalHTTP.HTTPClient, query string, startTime, endTime, outputFormat string) error {
 	query = ensureDefaultLimit(query)
 	body, err := json.Marshal(struct {
@@ -519,44 +726,206 @@ func fetchData(client *internalHTTP.HTTPClient, query string, startTime, endTime
 	}
 	defer resp.Body.Close()
 
-	stopSpinner = startSpinner()
-	respBody, err := io.ReadAll(resp.Body)
-	stopSpinner()
+	if resp.StatusCode != 200 {
+		preview, err := readLimitedErrorPreview(resp.Body)
+		if err != nil {
+			return fmt.Errorf("failed to read error response body: %w", err)
+		}
+		if preview == "" {
+			return fmt.Errorf("query failed: server returned %s with an empty response body", resp.Status)
+		}
+		return fmt.Errorf("query failed: server returned %s: %s", resp.Status, preview)
+	}
+
+	reader := bufio.NewReader(resp.Body)
+	if outputFormat == "json" {
+		return streamSQLJSONResponse(os.Stdout, reader, resp.Status)
+	}
+	return streamSQLTextResponse(os.Stdout, reader, resp.Status)
+}
+
+func readLimitedErrorPreview(body io.Reader) (string, error) {
+	limited := io.LimitReader(body, queryErrorPreviewLimit+1)
+	data, err := io.ReadAll(limited)
+	if err != nil {
+		return "", err
+	}
+	truncated := len(data) > queryErrorPreviewLimit
+	if truncated {
+		data = data[:queryErrorPreviewLimit]
+	}
+	preview := string(bytes.TrimSpace(data))
+	if truncated {
+		preview += "..."
+	}
+	return preview, nil
+}
+
+func streamSQLTextResponse(out io.Writer, reader *bufio.Reader, status string) error {
+	prefix, empty, err := readResponsePrefix(reader)
 	if err != nil {
 		return fmt.Errorf("failed to read response body: %w", err)
 	}
-	trimmedBody := bytes.TrimSpace(respBody)
-
-	if resp.StatusCode != 200 {
-		if len(trimmedBody) == 0 {
-			return fmt.Errorf("query failed: server returned %s with an empty response body", resp.Status)
-		}
-		return fmt.Errorf("query failed: server returned %s: %s", resp.Status, string(trimmedBody))
-	}
-
-	if len(trimmedBody) == 0 {
-		fmt.Printf("No response body returned (status: %s).\n", resp.Status)
-		return nil
-	}
-	if bytes.Equal(trimmedBody, []byte("[]")) && outputFormat != "json" {
-		fmt.Printf("Query succeeded: no rows returned (status: %s).\n", resp.Status)
+	if empty {
+		fmt.Fprintf(out, "No response body returned (status: %s).\n", status)
 		return nil
 	}
 
-	if outputFormat == "json" {
-		var jsonResponse []map[string]interface{}
-		if err := json.Unmarshal(respBody, &jsonResponse); err != nil {
-			return fmt.Errorf("error decoding JSON response: %w", err)
+	body := io.Reader(reader)
+	if firstNonSpace(prefix) == '[' {
+		isEmpty, consumed, err := consumeEmptyJSONArray(reader)
+		if err != nil {
+			return fmt.Errorf("failed to read response body: %w", err)
 		}
-		encodedResponse, _ := json.MarshalIndent(jsonResponse, "", "  ")
-		fmt.Println(string(encodedResponse))
-	} else {
-		fmt.Print(string(respBody))
-		if respBody[len(respBody)-1] != '\n' {
-			fmt.Println()
+		if isEmpty {
+			fmt.Fprintf(out, "Query succeeded: no rows returned (status: %s).\n", status)
+			return nil
 		}
+		body = io.MultiReader(bytes.NewReader(consumed), reader)
+	}
+
+	tracker := &trailingNewlineWriter{w: out}
+	if _, err := io.Copy(tracker, io.MultiReader(bytes.NewReader(prefix), body)); err != nil {
+		return fmt.Errorf("failed to stream response body: %w", err)
+	}
+	if tracker.wrote && tracker.last != '\n' {
+		fmt.Fprintln(out)
 	}
 	return nil
+}
+
+func streamSQLJSONResponse(out io.Writer, reader *bufio.Reader, status string) error {
+	prefix, empty, err := readResponsePrefix(reader)
+	if err != nil {
+		return fmt.Errorf("failed to read response body: %w", err)
+	}
+	if empty {
+		fmt.Fprintf(out, "No response body returned (status: %s).\n", status)
+		return nil
+	}
+	if err := writePrettyJSONArray(out, io.MultiReader(bytes.NewReader(prefix), reader)); err != nil {
+		return fmt.Errorf("error decoding JSON response: %w", err)
+	}
+	return nil
+}
+
+func readResponsePrefix(reader *bufio.Reader) ([]byte, bool, error) {
+	var prefix []byte
+	for {
+		b, err := reader.ReadByte()
+		if err == io.EOF {
+			return prefix, true, nil
+		}
+		if err != nil {
+			return prefix, false, err
+		}
+		prefix = append(prefix, b)
+		if !isSQLSpace(b) {
+			return prefix, false, nil
+		}
+	}
+}
+
+func consumeEmptyJSONArray(reader *bufio.Reader) (bool, []byte, error) {
+	var consumed []byte
+	for {
+		b, err := reader.ReadByte()
+		if err == io.EOF {
+			return false, consumed, nil
+		}
+		if err != nil {
+			return false, consumed, err
+		}
+		consumed = append(consumed, b)
+		if isSQLSpace(b) {
+			continue
+		}
+		if b != ']' {
+			return false, consumed, nil
+		}
+		break
+	}
+
+	for {
+		b, err := reader.ReadByte()
+		if err == io.EOF {
+			return true, consumed, nil
+		}
+		if err != nil {
+			return false, consumed, err
+		}
+		consumed = append(consumed, b)
+		if !isSQLSpace(b) {
+			return false, consumed, nil
+		}
+	}
+}
+
+func writePrettyJSONArray(out io.Writer, body io.Reader) error {
+	decoder := json.NewDecoder(body)
+	token, err := decoder.Token()
+	if err != nil {
+		return err
+	}
+	delim, ok := token.(json.Delim)
+	if !ok || delim != '[' {
+		return fmt.Errorf("expected JSON array response")
+	}
+
+	first := true
+	fmt.Fprint(out, "[")
+	for decoder.More() {
+		var item interface{}
+		if err := decoder.Decode(&item); err != nil {
+			return err
+		}
+		encoded, err := json.MarshalIndent(item, "", "  ")
+		if err != nil {
+			return err
+		}
+		if first {
+			fmt.Fprintln(out)
+			first = false
+		} else {
+			fmt.Fprintln(out, ",")
+		}
+		fmt.Fprint(out, "  ")
+		fmt.Fprint(out, string(bytes.ReplaceAll(encoded, []byte("\n"), []byte("\n  "))))
+	}
+	if _, err := decoder.Token(); err != nil {
+		return err
+	}
+	if first {
+		fmt.Fprintln(out, "]")
+	} else {
+		fmt.Fprintln(out)
+		fmt.Fprintln(out, "]")
+	}
+	return nil
+}
+
+func firstNonSpace(data []byte) byte {
+	for _, b := range data {
+		if !isSQLSpace(b) {
+			return b
+		}
+	}
+	return 0
+}
+
+type trailingNewlineWriter struct {
+	w     io.Writer
+	wrote bool
+	last  byte
+}
+
+func (w *trailingNewlineWriter) Write(p []byte) (int, error) {
+	n, err := w.w.Write(p)
+	if n > 0 {
+		w.wrote = true
+		w.last = p[n-1]
+	}
+	return n, err
 }
 
 func extractStreamName(query string) string {

--- a/cmd/query.go
+++ b/cmd/query.go
@@ -44,17 +44,19 @@ var (
 	endFlagShort = "t"
 	defaultEnd   = "now"
 
-	outputFlag = "output"
-	saveAsName string
+	outputFlag  = "output"
+	saveAsName  string
+	sqlSaveName string
 )
 
 var query = &cobra.Command{
-	Use:     "run [query] [flags]",
-	Example: "  pb query run \"select * from frontend\" --from=10m --to=now\n  pb query run \"select * from frontend\" -i",
-	Short:   "Run SQL query on a dataset",
-	Long:    "\nRun SQL query on a dataset. Default output format is text.\nUse --output json for JSON output, or -i for interactive table view.",
-	Args:    cobra.MaximumNArgs(1),
-	PreRunE: PreRunDefaultProfile,
+	Use:          "run [query] [flags]",
+	Example:      "  pb sql run \"select * from frontend\" --from=10m --to=now\n  pb sql run \"select * from frontend\" -i",
+	Short:        "Run SQL query on a dataset",
+	Long:         "\nRun SQL query on a dataset. Default output format is text.\nUse --output json for JSON output, or -i for interactive table view.",
+	Args:         cobra.MaximumNArgs(1),
+	SilenceUsage: true,
+	PreRunE:      PreRunDefaultProfile,
 	RunE: func(command *cobra.Command, args []string) error {
 		startTime := time.Now()
 		command.Annotations = map[string]string{
@@ -72,43 +74,9 @@ var query = &cobra.Command{
 			return err
 		}
 
-		usePromql, _ := command.Flags().GetBool("promql")
-		if usePromql && interactive {
-			start, _ := command.Flags().GetString(startFlag)
-			if !command.Flags().Changed(startFlag) {
-				start = "1h"
-			}
-			end, _ := command.Flags().GetString(endFlag)
-			if end == "" {
-				end = defaultEnd
-			}
-			startT, err := parseTimeStr(start)
-			if err != nil {
-				return fmt.Errorf("invalid --from: %w", err)
-			}
-			endT, err := parseTimeStr(end)
-			if err != nil {
-				return fmt.Errorf("invalid --to: %w", err)
-			}
-			dataset, _ := command.Flags().GetString("dataset")
-			step, _ := command.Flags().GetString("step")
-			instant, _ := command.Flags().GetBool("instant")
-			var expr string
-			if len(args) > 0 {
-				expr = args[0]
-			}
-			m := model.NewPromqlModel(DefaultProfile, expr, startT, endT, step, dataset, instant)
-			p := tea.NewProgram(m, tea.WithAltScreen())
-			_, err = p.Run()
-			if err != nil {
-				command.Annotations["error"] = err.Error()
-			}
-			return err
-		}
-
 		if (len(args) == 0 || strings.TrimSpace(args[0]) == "") && !interactive {
 			fmt.Println("Please enter your query")
-			fmt.Printf("Example:\n  pb query run \"select * from frontend\" --from=10m --to=now\n")
+			fmt.Printf("Example:\n  pb sql run \"select * from frontend\" --from=10m --to=now\n")
 			return nil
 		}
 
@@ -139,6 +107,7 @@ var query = &cobra.Command{
 
 		sqlQuery = quoteStreamNames(sqlQuery)
 		sqlQuery = quoteFieldsWithDots(sqlQuery)
+		sqlQuery = ensureDefaultLimit(sqlQuery)
 
 		if interactive {
 			startT, err := parseTimeStr(start)
@@ -165,9 +134,7 @@ var query = &cobra.Command{
 		}
 
 		client := internalHTTP.DefaultClient(&DefaultProfile)
-		stopSpinner := startSpinner()
 		err = fetchData(&client, sqlQuery, start, end, outputFmt)
-		stopSpinner()
 		if err != nil {
 			command.Annotations["error"] = err.Error()
 			return err
@@ -190,10 +157,6 @@ func init() {
 	query.Flags().StringVarP(&outputFormat, "output", "o", "", "Output format (text|json)")
 	query.Flags().BoolP("interactive", "i", false, "Open interactive table view")
 	query.Flags().StringVar(&saveAsName, "save-as", "", "Save this query with a name for later use")
-	query.Flags().Bool("promql", false, "Open PromQL interactive mode (use with -i)")
-	query.Flags().StringP("dataset", "d", defaultMetricsStream, "Metrics dataset (PromQL mode)")
-	query.Flags().String("step", "1m", "Resolution step for PromQL range queries")
-	query.Flags().Bool("instant", false, "PromQL instant query")
 }
 
 // parseTimeStr converts a CLI time string to time.Time.
@@ -260,10 +223,12 @@ func quoteStreamNames(query string) string {
 	})
 }
 
-// quoteFieldsWithDots wraps unquoted dotted identifiers in double quotes so
-// DataFusion treats them as field names instead of table.column references.
-// e.g. service.name → "service.name", http.status_code → "http.status_code"
-// Already-quoted identifiers and string literals are left untouched.
+// quoteFieldsWithDots wraps unquoted field identifiers that DataFusion would
+// otherwise reinterpret: dotted names become table.column references and
+// mixed-case names are folded to lowercase.
+// e.g. service.name → "service.name", StatusCode → "StatusCode"
+// Already-quoted identifiers, string literals, SQL keywords, and function calls
+// are left untouched.
 func quoteFieldsWithDots(query string) string {
 	var result strings.Builder
 	i, n := 0, len(query)
@@ -312,9 +277,10 @@ func quoteFieldsWithDots(query string) string {
 						k++
 					}
 				}
-				if hasDot {
+				identifier := query[i:k]
+				if hasDot || shouldQuoteIdentifier(identifier, query, k) {
 					result.WriteByte('"')
-					result.WriteString(query[i:k])
+					result.WriteString(identifier)
 					result.WriteByte('"')
 					i = k
 				} else {
@@ -330,6 +296,50 @@ func quoteFieldsWithDots(query string) string {
 	return result.String()
 }
 
+var sqlKeywords = map[string]struct{}{
+	"all": {}, "and": {}, "as": {}, "asc": {}, "between": {}, "by": {}, "case": {}, "cast": {},
+	"desc": {}, "distinct": {}, "else": {}, "end": {}, "false": {}, "from": {}, "full": {},
+	"group": {}, "having": {}, "in": {}, "inner": {}, "is": {}, "join": {}, "left": {}, "like": {},
+	"limit": {}, "not": {}, "null": {}, "on": {}, "or": {}, "order": {}, "outer": {}, "right": {},
+	"select": {}, "then": {}, "true": {}, "when": {}, "where": {},
+}
+
+func shouldQuoteIdentifier(identifier, query string, end int) bool {
+	if _, ok := sqlKeywords[strings.ToLower(identifier)]; ok {
+		return false
+	}
+	if nextNonSpace(query, end) == '(' {
+		return false
+	}
+	return hasMixedCase(identifier)
+}
+
+func hasMixedCase(s string) bool {
+	hasUpper, hasLower := false, false
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c >= 'A' && c <= 'Z' {
+			hasUpper = true
+		}
+		if c >= 'a' && c <= 'z' {
+			hasLower = true
+		}
+	}
+	return hasUpper && hasLower
+}
+
+func nextNonSpace(s string, start int) byte {
+	for start < len(s) {
+		switch s[start] {
+		case ' ', '\t', '\n', '\r':
+			start++
+		default:
+			return s[start]
+		}
+	}
+	return 0
+}
+
 func identStart(c byte) bool {
 	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || c == '_'
 }
@@ -340,7 +350,153 @@ func identChar(c byte) bool {
 
 var QueryCmd = query
 
+var SaveSQLCmd = &cobra.Command{
+	Use:          "save [query]",
+	Example:      "  pb sql save 'select * from frontend'\n  pb sql save \"select * from frontend\" --name frontend-errors --from=1h --to=now",
+	Short:        "Save SQL query",
+	Long:         "\nSave a SQL query without running it.",
+	Args:         cobra.ExactArgs(1),
+	SilenceUsage: true,
+	PreRunE:      PreRunDefaultProfile,
+	RunE: func(command *cobra.Command, args []string) error {
+		startTime := time.Now()
+		command.Annotations = map[string]string{
+			"startTime": startTime.Format(time.RFC3339),
+		}
+		defer func() {
+			command.Annotations["executionTime"] = time.Since(startTime).String()
+		}()
+
+		sqlQuery := strings.TrimSpace(args[0])
+		if sqlQuery == "" {
+			fmt.Println("Please enter your query")
+			fmt.Printf("Example:\n  pb sql save \"select * from frontend\"\n")
+			return nil
+		}
+
+		start, err := command.Flags().GetString(startFlag)
+		if err != nil {
+			command.Annotations["error"] = err.Error()
+			return err
+		}
+		if start == "" {
+			start = defaultStart
+		}
+
+		end, err := command.Flags().GetString(endFlag)
+		if err != nil {
+			command.Annotations["error"] = err.Error()
+			return err
+		}
+		if end == "" {
+			end = defaultEnd
+		}
+
+		sqlQuery = quoteStreamNames(sqlQuery)
+		sqlQuery = quoteFieldsWithDots(sqlQuery)
+		sqlQuery = ensureDefaultLimit(sqlQuery)
+
+		name := strings.TrimSpace(sqlSaveName)
+		if name == "" {
+			name = defaultSavedQueryName(sqlQuery)
+		}
+
+		client := internalHTTP.DefaultClient(&DefaultProfile)
+		if err := saveFilter(&client, sqlQuery, name, start, end); err != nil {
+			command.Annotations["error"] = err.Error()
+			return err
+		}
+
+		fmt.Printf("Query saved as '%s'\n", name)
+		command.Annotations["error"] = "none"
+		return nil
+	},
+}
+
+func init() {
+	SaveSQLCmd.Flags().StringP(startFlag, startFlagShort, defaultStart, "Start time for query.")
+	SaveSQLCmd.Flags().StringP(endFlag, endFlagShort, defaultEnd, "End time for query.")
+	SaveSQLCmd.Flags().StringVar(&sqlSaveName, "name", "", "Saved query name. Defaults to the dataset name when available.")
+}
+
+func defaultSavedQueryName(sqlQuery string) string {
+	if stream := extractStreamName(sqlQuery); stream != "" {
+		return stream
+	}
+	return "saved-query"
+}
+
+func ensureDefaultLimit(query string) string {
+	trimmed := strings.TrimSpace(query)
+	if trimmed == "" || hasTopLevelLimit(trimmed) {
+		return query
+	}
+	suffix := ""
+	if strings.HasSuffix(trimmed, ";") {
+		trimmed = strings.TrimSpace(strings.TrimSuffix(trimmed, ";"))
+		suffix = ";"
+	}
+	return trimmed + " LIMIT 500" + suffix
+}
+
+func hasTopLevelLimit(query string) bool {
+	depth := 0
+	for i := 0; i < len(query); {
+		switch query[i] {
+		case '\'':
+			i++
+			for i < len(query) {
+				if query[i] == '\'' {
+					i++
+					if i < len(query) && query[i] == '\'' {
+						i++
+						continue
+					}
+					break
+				}
+				i++
+			}
+		case '"':
+			i++
+			for i < len(query) {
+				if query[i] == '"' {
+					i++
+					break
+				}
+				i++
+			}
+		case '(':
+			depth++
+			i++
+		case ')':
+			if depth > 0 {
+				depth--
+			}
+			i++
+		default:
+			if depth == 0 && isLimitTokenAt(query, i) {
+				return true
+			}
+			i++
+		}
+	}
+	return false
+}
+
+func isLimitTokenAt(query string, idx int) bool {
+	const token = "limit"
+	if idx+len(token) > len(query) || !strings.EqualFold(query[idx:idx+len(token)], token) {
+		return false
+	}
+	if idx > 0 && identChar(query[idx-1]) {
+		return false
+	}
+	next := idx + len(token)
+	return next >= len(query) || !identChar(query[next])
+}
+
 func fetchData(client *internalHTTP.HTTPClient, query string, startTime, endTime, outputFormat string) error {
+	query = ensureDefaultLimit(query)
 	body, err := json.Marshal(struct {
 		Query     string `json:"query"`
 		StartTime string `json:"startTime"`
@@ -355,27 +511,50 @@ func fetchData(client *internalHTTP.HTTPClient, query string, startTime, endTime
 		return fmt.Errorf("failed to create new request: %w", err)
 	}
 
+	stopSpinner := startSpinner()
 	resp, err := client.Client.Do(req)
+	stopSpinner()
 	if err != nil {
 		return fmt.Errorf("request execution failed: %w", err)
 	}
 	defer resp.Body.Close()
 
+	stopSpinner = startSpinner()
+	respBody, err := io.ReadAll(resp.Body)
+	stopSpinner()
+	if err != nil {
+		return fmt.Errorf("failed to read response body: %w", err)
+	}
+	trimmedBody := bytes.TrimSpace(respBody)
+
 	if resp.StatusCode != 200 {
-		body, _ := io.ReadAll(resp.Body)
-		fmt.Println(string(body))
-		return fmt.Errorf("non-200 status code received: %s", resp.Status)
+		if len(trimmedBody) == 0 {
+			return fmt.Errorf("query failed: server returned %s with an empty response body", resp.Status)
+		}
+		return fmt.Errorf("query failed: server returned %s: %s", resp.Status, string(trimmedBody))
+	}
+
+	if len(trimmedBody) == 0 {
+		fmt.Printf("No response body returned (status: %s).\n", resp.Status)
+		return nil
+	}
+	if bytes.Equal(trimmedBody, []byte("[]")) && outputFormat != "json" {
+		fmt.Printf("Query succeeded: no rows returned (status: %s).\n", resp.Status)
+		return nil
 	}
 
 	if outputFormat == "json" {
 		var jsonResponse []map[string]interface{}
-		if err := json.NewDecoder(resp.Body).Decode(&jsonResponse); err != nil {
+		if err := json.Unmarshal(respBody, &jsonResponse); err != nil {
 			return fmt.Errorf("error decoding JSON response: %w", err)
 		}
 		encodedResponse, _ := json.MarshalIndent(jsonResponse, "", "  ")
 		fmt.Println(string(encodedResponse))
 	} else {
-		io.Copy(os.Stdout, resp.Body)
+		fmt.Print(string(respBody))
+		if respBody[len(respBody)-1] != '\n' {
+			fmt.Println()
+		}
 	}
 	return nil
 }

--- a/cmd/queryList.go
+++ b/cmd/queryList.go
@@ -30,11 +30,13 @@ import (
 )
 
 var SavedQueryList = &cobra.Command{
-	Use:     "list",
-	Example: "pb query list [-o | --output]",
-	Short:   "List of saved queries",
-	Long:    "\nShow the list of saved queries for active user",
-	PreRunE: PreRunDefaultProfile,
+	Use:          "list",
+	Aliases:      []string{"ls"},
+	Example:      "pb sql list [-o | --output]",
+	Short:        "List of saved queries",
+	Long:         "\nShow the list of saved queries for active user",
+	SilenceUsage: true,
+	PreRunE:      PreRunDefaultProfile,
 	RunE: func(_ *cobra.Command, _ []string) error {
 		client := internalHTTP.DefaultClient(&DefaultProfile)
 
@@ -107,7 +109,7 @@ var SavedQueryList = &cobra.Command{
 
 		a := model.QueryToApply()
 		d := model.QueryToDelete()
-		if a.Stream() != "" {
+		if a.SavedQueryID() != "" || strings.TrimSpace(a.Stream()) != "" {
 			if err := savedQueryToPbQuery(a.Stream(), a.StartTime(), a.EndTime()); err != nil {
 				return err
 			}
@@ -139,8 +141,13 @@ func deleteSavedQuery(client *internalHTTP.HTTPClient, savedQueryID, title strin
 	}
 }
 
-// Convert a saved query to executable pb query and print results to terminal
+// Convert a saved query to executable SQL query and print results to terminal.
 func savedQueryToPbQuery(sqlQuery string, start string, end string) error {
+	if strings.TrimSpace(sqlQuery) == "" {
+		fmt.Println("Empty query selected.")
+		return nil
+	}
+
 	if start == "" {
 		start = "1h"
 	}
@@ -154,10 +161,11 @@ func savedQueryToPbQuery(sqlQuery string, start string, end string) error {
 	fmt.Printf("Query: %s\n", sqlQuery)
 
 	client := internalHTTP.DefaultClient(&DefaultProfile)
-	stopSpinner := startSpinner()
 	err := fetchData(&client, sqlQuery, start, end, "")
-	stopSpinner()
-	return err
+	if err != nil {
+		return fmt.Errorf("selected saved query failed: %w", err)
+	}
+	return nil
 }
 
 func init() {

--- a/cmd/queryList_test.go
+++ b/cmd/queryList_test.go
@@ -1,0 +1,31 @@
+package cmd
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"testing"
+)
+
+func TestSavedQueryToPbQueryPrintsEmptyQueryMessage(t *testing.T) {
+	var output bytes.Buffer
+	oldStdout := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe failed: %v", err)
+	}
+	os.Stdout = w
+
+	err = savedQueryToPbQuery("   ", "", "")
+
+	w.Close()
+	os.Stdout = oldStdout
+	io.Copy(&output, r)
+
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if got, want := output.String(), "Empty query selected.\n"; got != want {
+		t.Fatalf("unexpected output\nwant: %q\n got: %q", want, got)
+	}
+}

--- a/cmd/queryList_test.go
+++ b/cmd/queryList_test.go
@@ -14,13 +14,17 @@ func TestSavedQueryToPbQueryPrintsEmptyQueryMessage(t *testing.T) {
 	if err != nil {
 		t.Fatalf("pipe failed: %v", err)
 	}
+	t.Cleanup(func() {
+		os.Stdout = oldStdout
+		_ = w.Close()
+		_ = r.Close()
+	})
 	os.Stdout = w
 
 	err = savedQueryToPbQuery("   ", "", "")
 
-	w.Close()
-	os.Stdout = oldStdout
-	io.Copy(&output, r)
+	_ = w.Close()
+	_, _ = io.Copy(&output, r)
 
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)

--- a/cmd/query_test.go
+++ b/cmd/query_test.go
@@ -1,0 +1,86 @@
+package cmd
+
+import "testing"
+
+func normalizeSQLQueryForTest(query string) string {
+	query = quoteStreamNames(query)
+	query = quoteFieldsWithDots(query)
+	return query
+}
+
+func TestNormalizeSQLQueryQuotesShellStrippedIdentifiers(t *testing.T) {
+	input := "SELECT * FROM astronomy-shop-logs WHERE StatusCode = 'FailedPrecondition' AND service.name = 'cart' LIMIT 500"
+	want := `SELECT * FROM "astronomy-shop-logs" WHERE "StatusCode" = 'FailedPrecondition' AND "service.name" = 'cart' LIMIT 500`
+
+	if got := normalizeSQLQueryForTest(input); got != want {
+		t.Fatalf("normalized query mismatch\nwant: %s\n got: %s", want, got)
+	}
+}
+
+func TestNormalizeSQLQueryLeavesQuotedIdentifiersAndStringsAlone(t *testing.T) {
+	input := `SELECT * FROM "astronomy-shop-logs" WHERE "StatusCode" = 'FailedPrecondition' AND "service.name" = 'cart'`
+
+	if got := normalizeSQLQueryForTest(input); got != input {
+		t.Fatalf("quoted query changed\nwant: %s\n got: %s", input, got)
+	}
+}
+
+func TestNormalizeSQLQueryDoesNotQuoteKeywordsOrFunctionNames(t *testing.T) {
+	input := "SELECT COUNT(StatusCode) FROM astronomy-shop-logs WHERE StatusCode IS NOT NULL GROUP BY service.name LIMIT 10"
+	want := `SELECT COUNT("StatusCode") FROM "astronomy-shop-logs" WHERE "StatusCode" IS NOT NULL GROUP BY "service.name" LIMIT 10`
+
+	if got := normalizeSQLQueryForTest(input); got != want {
+		t.Fatalf("normalized query mismatch\nwant: %s\n got: %s", want, got)
+	}
+}
+
+func TestDefaultSavedQueryNameUsesStreamName(t *testing.T) {
+	query := `SELECT * FROM "astronomy-shop-logs" LIMIT 500`
+
+	if got := defaultSavedQueryName(query); got != "astronomy-shop-logs" {
+		t.Fatalf("got %q, want astronomy-shop-logs", got)
+	}
+}
+
+func TestDefaultSavedQueryNameFallback(t *testing.T) {
+	query := `SELECT 1`
+
+	if got := defaultSavedQueryName(query); got != "saved-query" {
+		t.Fatalf("got %q, want saved-query", got)
+	}
+}
+
+func TestEnsureDefaultLimitAddsLimit(t *testing.T) {
+	query := `SELECT * FROM "astronomy-shop-logs"`
+	want := `SELECT * FROM "astronomy-shop-logs" LIMIT 500`
+
+	if got := ensureDefaultLimit(query); got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestEnsureDefaultLimitKeepsExistingTopLevelLimit(t *testing.T) {
+	query := `SELECT * FROM "astronomy-shop-logs" LIMIT 10`
+
+	if got := ensureDefaultLimit(query); got != query {
+		t.Fatalf("got %q, want %q", got, query)
+	}
+}
+
+func TestEnsureDefaultLimitIgnoresSubqueryLimit(t *testing.T) {
+	query := `SELECT * FROM (SELECT * FROM "astronomy-shop-logs" LIMIT 10) logs`
+	want := `SELECT * FROM (SELECT * FROM "astronomy-shop-logs" LIMIT 10) logs LIMIT 500`
+
+	if got := ensureDefaultLimit(query); got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestEnsureDefaultLimitKeepsTrailingSemicolon(t *testing.T) {
+	query := `SELECT * FROM "astronomy-shop-logs";`
+	want := `SELECT * FROM "astronomy-shop-logs" LIMIT 500;`
+
+	if got := ensureDefaultLimit(query); got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}

--- a/cmd/query_test.go
+++ b/cmd/query_test.go
@@ -1,6 +1,11 @@
 package cmd
 
-import "testing"
+import (
+	"bufio"
+	"bytes"
+	"strings"
+	"testing"
+)
 
 func normalizeSQLQueryForTest(query string) string {
 	query = quoteStreamNames(query)
@@ -14,6 +19,36 @@ func TestNormalizeSQLQueryQuotesShellStrippedIdentifiers(t *testing.T) {
 
 	if got := normalizeSQLQueryForTest(input); got != want {
 		t.Fatalf("normalized query mismatch\nwant: %s\n got: %s", want, got)
+	}
+}
+
+func TestNormalizeSQLQueryLeavesUnderscoreDatasetNameAlone(t *testing.T) {
+	input := `SELECT * FROM fly_logs LIMIT 100`
+
+	if got := normalizeSQLQueryForTest(input); got != input {
+		t.Fatalf("underscore dataset changed\nwant: %s\n got: %s", input, got)
+	}
+}
+
+func TestNormalizeSQLQueryQuotesUnsafeJoinDatasetName(t *testing.T) {
+	input := `SELECT * FROM fly_logs JOIN claudecode-logs ON fly_logs.id = claudecode-logs.id`
+	want := `SELECT * FROM fly_logs JOIN "claudecode-logs" ON fly_logs.id = claudecode-logs.id`
+
+	if got := quoteStreamNames(input); got != want {
+		t.Fatalf("normalized query mismatch\nwant: %s\n got: %s", want, got)
+	}
+}
+
+func TestNormalizeSQLQueryQuotesDatasetNamesWithDotsOrLeadingDigits(t *testing.T) {
+	tests := map[string]string{
+		`SELECT * FROM metrics.v1 LIMIT 100`: `SELECT * FROM "metrics.v1" LIMIT 100`,
+		`SELECT * FROM 123logs LIMIT 100`:    `SELECT * FROM "123logs" LIMIT 100`,
+	}
+
+	for input, want := range tests {
+		if got := quoteStreamNames(input); got != want {
+			t.Fatalf("quoteStreamNames(%q) = %q, want %q", input, got, want)
+		}
 	}
 }
 
@@ -82,5 +117,103 @@ func TestEnsureDefaultLimitKeepsTrailingSemicolon(t *testing.T) {
 
 	if got := ensureDefaultLimit(query); got != want {
 		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestEnsureDefaultLimitIgnoresLimitInComments(t *testing.T) {
+	tests := map[string]string{
+		`SELECT * FROM logs -- limit later`:         "SELECT * FROM logs -- limit later\nLIMIT 500",
+		`SELECT * FROM logs /* limit later */`:      `SELECT * FROM logs /* limit later */ LIMIT 500`,
+		`SELECT * FROM logs -- limit later` + "\n":  "SELECT * FROM logs -- limit later\nLIMIT 500",
+		`SELECT * FROM logs WHERE msg = 'limit 1'`:  `SELECT * FROM logs WHERE msg = 'limit 1' LIMIT 500`,
+		`SELECT * FROM logs WHERE "limit" = 'true'`: `SELECT * FROM logs WHERE "limit" = 'true' LIMIT 500`,
+	}
+
+	for query, want := range tests {
+		if got := ensureDefaultLimit(query); got != want {
+			t.Fatalf("ensureDefaultLimit(%q) = %q, want %q", query, got, want)
+		}
+	}
+}
+
+func TestEnsureDefaultLimitKeepsRealLimitWithComments(t *testing.T) {
+	tests := []string{
+		`SELECT * FROM logs LIMIT 10 -- keep`,
+		`SELECT * FROM logs /* comment */ LIMIT 10`,
+	}
+
+	for _, query := range tests {
+		if got := ensureDefaultLimit(query); got != query {
+			t.Fatalf("ensureDefaultLimit(%q) = %q, want unchanged", query, got)
+		}
+	}
+}
+
+func TestStreamSQLTextResponseStreamsBodyAndAddsTrailingNewline(t *testing.T) {
+	var output bytes.Buffer
+	reader := bufio.NewReader(strings.NewReader(`[{"a":1}]`))
+
+	if err := streamSQLTextResponse(&output, reader, "200 OK"); err != nil {
+		t.Fatalf("streamSQLTextResponse failed: %v", err)
+	}
+
+	if got, want := output.String(), "[{\"a\":1}]\n"; got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestStreamSQLTextResponsePrintsNoRowsForEmptyArray(t *testing.T) {
+	var output bytes.Buffer
+	reader := bufio.NewReader(strings.NewReader("  []\n"))
+
+	if err := streamSQLTextResponse(&output, reader, "200 OK"); err != nil {
+		t.Fatalf("streamSQLTextResponse failed: %v", err)
+	}
+
+	if got, want := output.String(), "Query succeeded: no rows returned (status: 200 OK).\n"; got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestStreamSQLJSONResponsePrettyPrintsArray(t *testing.T) {
+	var output bytes.Buffer
+	reader := bufio.NewReader(strings.NewReader(`[{"b":2},{"a":1}]`))
+
+	if err := streamSQLJSONResponse(&output, reader, "200 OK"); err != nil {
+		t.Fatalf("streamSQLJSONResponse failed: %v", err)
+	}
+
+	want := "[\n  {\n    \"b\": 2\n  },\n  {\n    \"a\": 1\n  }\n]\n"
+	if got := output.String(); got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestStreamSQLJSONResponsePrintsEmptyArray(t *testing.T) {
+	var output bytes.Buffer
+	reader := bufio.NewReader(strings.NewReader(`[]`))
+
+	if err := streamSQLJSONResponse(&output, reader, "200 OK"); err != nil {
+		t.Fatalf("streamSQLJSONResponse failed: %v", err)
+	}
+
+	if got, want := output.String(), "[]\n"; got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestReadLimitedErrorPreviewTruncatesLargeBody(t *testing.T) {
+	body := strings.NewReader(strings.Repeat("x", queryErrorPreviewLimit+10))
+
+	preview, err := readLimitedErrorPreview(body)
+	if err != nil {
+		t.Fatalf("readLimitedErrorPreview failed: %v", err)
+	}
+
+	if len(preview) != queryErrorPreviewLimit+len("...") {
+		t.Fatalf("preview length = %d, want %d", len(preview), queryErrorPreviewLimit+len("..."))
+	}
+	if !strings.HasSuffix(preview, "...") {
+		t.Fatalf("preview should indicate truncation")
 	}
 }

--- a/cmd/role.go
+++ b/cmd/role.go
@@ -246,10 +246,16 @@ var ListRoleCmd = &cobra.Command{
 		}
 
 		printRoleTable(roles, roleResponses)
+		var fetchErrors []string
 		for idx, roleName := range roles {
 			if roleResponses[idx].err != nil {
-				cmd.Annotations["errors"] += fmt.Sprintf("Error fetching role data for %s: %v\n", roleName, roleResponses[idx].err)
+				errMsg := fmt.Sprintf("Error fetching role data for %s: %v", roleName, roleResponses[idx].err)
+				fetchErrors = append(fetchErrors, errMsg)
+				cmd.Annotations["errors"] += errMsg + "\n"
 			}
+		}
+		if len(fetchErrors) > 0 {
+			return fmt.Errorf("failed to fetch details for %d role(s): %s", len(fetchErrors), strings.Join(fetchErrors, "; "))
 		}
 
 		return nil

--- a/cmd/role.go
+++ b/cmd/role.go
@@ -188,9 +188,11 @@ var RemoveRoleCmd = &cobra.Command{
 }
 
 var ListRoleCmd = &cobra.Command{
-	Use:     "list",
-	Short:   "List all roles",
-	Example: "  pb role list",
+	Use:          "list",
+	Aliases:      []string{"ls"},
+	Short:        "List all roles",
+	Example:      "  pb role list",
+	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, _ []string) error {
 		startTime := time.Now()
 		cmd.Annotations = make(map[string]string)
@@ -243,23 +245,145 @@ var ListRoleCmd = &cobra.Command{
 			return nil
 		}
 
-		fmt.Println()
+		printRoleTable(roles, roleResponses)
 		for idx, roleName := range roles {
-			fetchRes := roleResponses[idx]
-			fmt.Print("• ")
-			fmt.Println(StandardStyleBold.Bold(true).Render(roleName))
-			if fetchRes.err == nil {
-				for _, role := range fetchRes.data {
-					fmt.Println(lipgloss.NewStyle().PaddingLeft(3).Render(role.Render()))
-				}
-			} else {
-				fmt.Printf("Error fetching role data for %s: %v\n", roleName, fetchRes.err)
-				cmd.Annotations["errors"] += fmt.Sprintf("Error fetching role data for %s: %v\n", roleName, fetchRes.err)
+			if roleResponses[idx].err != nil {
+				cmd.Annotations["errors"] += fmt.Sprintf("Error fetching role data for %s: %v\n", roleName, roleResponses[idx].err)
 			}
 		}
 
 		return nil
 	},
+}
+
+func printRoleTable(roles []string, roleResponses []struct {
+	data []RoleData
+	err  error
+}) {
+	const maxRoleWidth = 42
+	const maxStreamWidth = 48
+
+	roleWidth := lipgloss.Width("ROLE")
+	privilegeWidth := lipgloss.Width("PRIVILEGE")
+	streamWidth := lipgloss.Width("STREAM")
+
+	for idx, roleName := range roles {
+		roleW := lipgloss.Width(roleName)
+		if roleW > maxRoleWidth {
+			roleW = maxRoleWidth
+		}
+		if roleW > roleWidth {
+			roleWidth = roleW
+		}
+		for _, action := range roleResponses[idx].data {
+			if w := lipgloss.Width(action.Privilege); w > privilegeWidth {
+				privilegeWidth = w
+			}
+			stream := roleStream(action)
+			streamW := lipgloss.Width(stream)
+			if streamW > maxStreamWidth {
+				streamW = maxStreamWidth
+			}
+			if streamW > streamWidth {
+				streamWidth = streamW
+			}
+		}
+	}
+
+	headerStyle := SelectedStyle.Bold(true)
+	bodyStyle := StandardStyle
+	mutedStyle := StandardStyleAlt
+	ruleStyle := StandardStyleRule
+	leaderStyle := StandardStyleRule
+	privilegeColumn := roleWidth + 4
+	streamColumn := privilegeColumn + privilegeWidth + 4
+
+	renderRoleGuide := func(roleCell string) string {
+		if roleCell == "" {
+			return strings.Repeat(" ", privilegeColumn)
+		}
+		leaderWidth := privilegeColumn - lipgloss.Width(roleCell) - 1
+		if leaderWidth < 2 {
+			leaderWidth = 2
+		}
+		return bodyStyle.Render(roleCell) + " " + leaderStyle.Render(strings.Repeat(".", leaderWidth))
+	}
+
+	renderPrivilegeGuide := func(privilegeCell string, style lipgloss.Style) string {
+		privilegeCell = truncateCell(privilegeCell, privilegeWidth)
+		leaderWidth := streamColumn - privilegeColumn - lipgloss.Width(privilegeCell) - 1
+		if leaderWidth < 2 {
+			leaderWidth = 2
+		}
+		return style.Render(privilegeCell) + " " + leaderStyle.Render(strings.Repeat(".", leaderWidth))
+	}
+
+	printRow := func(roleCell, privilegeCell string, privilegeStyle lipgloss.Style, streamCell string, streamStyle lipgloss.Style) {
+		fmt.Printf("%s %s %s\n",
+			renderRoleGuide(roleCell),
+			renderPrivilegeGuide(privilegeCell, privilegeStyle),
+			streamStyle.Render(truncateCell(streamCell, maxStreamWidth)),
+		)
+	}
+
+	fmt.Println()
+	fmt.Printf("%s%s%s\n",
+		headerStyle.Render(padRight("ROLE", privilegeColumn+1)),
+		headerStyle.Render(padRight("PRIVILEGE", privilegeWidth+5)),
+		headerStyle.Render("STREAM"),
+	)
+	fmt.Printf("%s%s%s\n",
+		ruleStyle.Render(strings.Repeat("─", privilegeColumn+1)),
+		ruleStyle.Render(strings.Repeat("─", privilegeWidth+5)),
+		ruleStyle.Render(strings.Repeat("─", streamWidth)),
+	)
+
+	for idx, roleName := range roles {
+		fetchRes := roleResponses[idx]
+		if fetchRes.err != nil {
+			printRow(
+				truncateCell(roleName, maxRoleWidth),
+				"-",
+				mutedStyle,
+				fmt.Sprintf("error: %v", fetchRes.err),
+				mutedStyle,
+			)
+			continue
+		}
+
+		if len(fetchRes.data) == 0 {
+			printRow(truncateCell(roleName, maxRoleWidth), "-", mutedStyle, "-", mutedStyle)
+			continue
+		}
+
+		for actionIdx, action := range fetchRes.data {
+			roleCell := ""
+			if actionIdx == 0 {
+				roleCell = truncateCell(roleName, maxRoleWidth)
+			}
+			stream := roleStream(action)
+			streamStyle := bodyStyle
+			if stream == "-" {
+				streamStyle = mutedStyle
+			}
+			printRow(roleCell, orDash(action.Privilege), bodyStyle, stream, streamStyle)
+		}
+	}
+	fmt.Println()
+}
+
+func roleStream(action RoleData) string {
+	if action.Resource == nil || action.Resource.Stream == "" {
+		return "-"
+	}
+	return action.Resource.Stream
+}
+
+func orDash(value string) string {
+	if strings.TrimSpace(value) == "" {
+		return "-"
+	}
+	return value
 }
 
 func fetchRoles(client *internalHTTP.HTTPClient, data *[]string) error {

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -20,7 +20,10 @@ import (
 	"pb/pkg/analytics"
 	"pb/pkg/config"
 	internalHTTP "pb/pkg/http"
+	"pb/pkg/ui"
+	"strings"
 
+	"github.com/charmbracelet/lipgloss"
 	"github.com/spf13/cobra"
 )
 
@@ -46,13 +49,23 @@ var StatusCmd = &cobra.Command{
 		client := internalHTTP.DefaultClient(&profile)
 		about, err := analytics.FetchAbout(&client)
 		if err != nil {
-			fmt.Printf("Status  : ✗ Not connected\n")
-			fmt.Printf("Error   : %s\n", err.Error())
+			errStyle := lipgloss.NewStyle().Foreground(ui.Active.Err).Bold(true)
+			fmt.Printf("Status  : %s\n", errStyle.Render("✗ Not connected"))
+			fmt.Printf("Error   : %s\n", statusErrorMessage(err))
 			return nil
 		}
 
-		fmt.Printf("Status  : ✓ Connected\n")
+		okStyle := lipgloss.NewStyle().Foreground(ui.Active.Ok).Bold(true)
+		fmt.Printf("Status  : %s\n", okStyle.Render("✓ Connected"))
 		fmt.Printf("Version : %s\n", about.Version)
 		return nil
 	},
+}
+
+func statusErrorMessage(err error) string {
+	message := err.Error()
+	if strings.Contains(message, "Status Code: 401") || strings.Contains(message, "Status Code: 403") {
+		return "Authentication failed: invalid username/password or API key"
+	}
+	return message
 }

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -49,10 +49,11 @@ var StatusCmd = &cobra.Command{
 		client := internalHTTP.DefaultClient(&profile)
 		about, err := analytics.FetchAbout(&client)
 		if err != nil {
+			statusMessage := statusErrorMessage(err)
 			errStyle := lipgloss.NewStyle().Foreground(ui.Active.Err).Bold(true)
 			fmt.Printf("Status  : %s\n", errStyle.Render("✗ Not connected"))
-			fmt.Printf("Error   : %s\n", statusErrorMessage(err))
-			return nil
+			fmt.Printf("Error   : %s\n", statusMessage)
+			return fmt.Errorf("status check failed: %s", statusMessage)
 		}
 
 		okStyle := lipgloss.NewStyle().Foreground(ui.Active.Ok).Bold(true)

--- a/cmd/status_test.go
+++ b/cmd/status_test.go
@@ -1,0 +1,23 @@
+package cmd
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestStatusErrorMessageTreatsAuthFailuresAsCredentialErrors(t *testing.T) {
+	input := errors.New("Request Failed\nStatus Code: 403 Forbidden\nResponse: You don't have permission")
+	got := statusErrorMessage(input)
+	want := "Authentication failed: invalid username/password or API key"
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestStatusErrorMessageKeepsOtherErrors(t *testing.T) {
+	input := errors.New("dial tcp: connection refused")
+	got := statusErrorMessage(input)
+	if got != input.Error() {
+		t.Fatalf("got %q, want %q", got, input.Error())
+	}
+}

--- a/cmd/style.go
+++ b/cmd/style.go
@@ -41,6 +41,7 @@ var (
 	StandardStyle     = lipgloss.NewStyle().Foreground(StandardPrimary)
 	StandardStyleBold = lipgloss.NewStyle().Foreground(StandardPrimary).Bold(true)
 	StandardStyleAlt  = lipgloss.NewStyle().Foreground(StandardSecondary)
+	StandardStyleRule = lipgloss.NewStyle().Foreground(ui.Adaptive(func(p ui.Palette) lipgloss.Color { return p.Border }))
 	SelectedStyle     = lipgloss.NewStyle().Foreground(FocusPrimary).Bold(true)
 	SelectedStyleAlt  = lipgloss.NewStyle().Foreground(FocusSecondary)
 	SelectedItemOuter = lipgloss.NewStyle().

--- a/cmd/user.go
+++ b/cmd/user.go
@@ -275,9 +275,11 @@ var SetUserRoleCmd = &cobra.Command{
 }
 
 var ListUserCmd = &cobra.Command{
-	Use:     "list",
-	Short:   "List all users",
-	Example: "  pb user list",
+	Use:          "list",
+	Aliases:      []string{"ls"},
+	Short:        "List all users",
+	Example:      "  pb user list",
+	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, _ []string) error {
 		startTime := time.Now()
 		cmd.Annotations = make(map[string]string)
@@ -347,39 +349,103 @@ var ListUserCmd = &cobra.Command{
 		}
 
 		if outputFormat == "text" {
-			fmt.Println()
-			for idx, user := range users {
-				roles := roleResponses[idx]
-				if roles.err == nil {
-					roleList := strings.Join(roles.data, ", ")
-					fmt.Printf("%s, %s\n", user.ID, roleList)
-				} else {
-					fmt.Printf("%s, error: %v\n", user.ID, roles.err)
-				}
-			}
-			fmt.Println()
+			printUserRoleTable(users, roleResponses)
 			cmd.Annotations["error"] = "none"
 			return nil
 		}
 
-		fmt.Println()
-		for idx, user := range users {
-			roles := roleResponses[idx]
-			fmt.Print("• ")
-			fmt.Println(StandardStyleBold.Bold(true).Render(user.ID))
-			if roles.err == nil {
-				for _, role := range roles.data {
-					fmt.Println(lipgloss.NewStyle().PaddingLeft(3).Render(role))
-				}
-			} else {
-				fmt.Println(roles.err)
-			}
-		}
-		fmt.Println()
+		printUserRoleTable(users, roleResponses)
 
 		cmd.Annotations["error"] = "none"
 		return nil
 	},
+}
+
+func printUserRoleTable(users []UserData, roleResponses []struct {
+	data []string
+	err  error
+}) {
+	const maxUserWidth = 64
+	userHeader := "USER"
+	rolesHeader := "ROLES"
+	userWidth := lipgloss.Width(userHeader)
+	for _, user := range users {
+		width := lipgloss.Width(user.ID)
+		if width > maxUserWidth {
+			width = maxUserWidth
+		}
+		if width > userWidth {
+			userWidth = width
+		}
+	}
+
+	headerStyle := SelectedStyle.Bold(true)
+	bodyStyle := StandardStyle
+	mutedStyle := StandardStyleAlt
+	ruleStyle := StandardStyleRule
+	leaderStyle := StandardStyleRule
+	roleColumn := userWidth + 4
+
+	fmt.Println()
+	fmt.Printf("%s%s\n",
+		headerStyle.Render(padRight(userHeader, roleColumn)),
+		headerStyle.Render(rolesHeader),
+	)
+	fmt.Printf("%s%s\n",
+		ruleStyle.Render(strings.Repeat("─", roleColumn)),
+		ruleStyle.Render(strings.Repeat("─", lipgloss.Width(rolesHeader))),
+	)
+	for idx, user := range users {
+		roles := roleResponses[idx]
+		roleText := "-"
+		roleStyle := bodyStyle
+		if roles.err != nil {
+			roleText = fmt.Sprintf("error: %v", roles.err)
+			roleStyle = mutedStyle
+		} else if len(roles.data) > 0 {
+			roleText = strings.Join(roles.data, ", ")
+		} else {
+			roleStyle = mutedStyle
+		}
+		userCell := truncateCell(user.ID, maxUserWidth)
+		leaderWidth := roleColumn - lipgloss.Width(userCell) - 1
+		if leaderWidth < 2 {
+			leaderWidth = 2
+		}
+
+		fmt.Printf("%s %s %s\n",
+			bodyStyle.Render(userCell),
+			leaderStyle.Render(strings.Repeat(".", leaderWidth)),
+			roleStyle.Render(roleText),
+		)
+	}
+	fmt.Println()
+}
+
+func padRight(value string, width int) string {
+	padding := width - lipgloss.Width(value)
+	if padding < 0 {
+		padding = 0
+	}
+	return value + strings.Repeat(" ", padding)
+}
+
+func truncateCell(value string, width int) string {
+	if lipgloss.Width(value) <= width {
+		return value
+	}
+	if width <= 1 {
+		return "…"
+	}
+	out := ""
+	for _, r := range value {
+		next := out + string(r)
+		if lipgloss.Width(next)+1 > width {
+			break
+		}
+		out = next
+	}
+	return out + "…"
 }
 
 func fetchUsers(client *internalHTTP.HTTPClient) (res []UserData, err error) {

--- a/cmd/user.go
+++ b/cmd/user.go
@@ -344,21 +344,37 @@ var ListUserCmd = &cobra.Command{
 				return fmt.Errorf("failed to marshal JSON output: %w", err)
 			}
 			fmt.Println(string(jsonOutput))
-			cmd.Annotations["error"] = "none"
-			return nil
+			return userRoleFetchError(cmd, users, roleResponses)
 		}
 
 		if outputFormat == "text" {
 			printUserRoleTable(users, roleResponses)
-			cmd.Annotations["error"] = "none"
-			return nil
+			return userRoleFetchError(cmd, users, roleResponses)
 		}
 
 		printUserRoleTable(users, roleResponses)
 
+		return userRoleFetchError(cmd, users, roleResponses)
+	},
+}
+
+func userRoleFetchError(cmd *cobra.Command, users []UserData, roleResponses []struct {
+	data []string
+	err  error
+}) error {
+	var fetchErrors []string
+	for idx, user := range users {
+		if roleResponses[idx].err != nil {
+			errMsg := fmt.Sprintf("Error fetching roles for %s: %v", user.ID, roleResponses[idx].err)
+			fetchErrors = append(fetchErrors, errMsg)
+		}
+	}
+	if len(fetchErrors) == 0 {
 		cmd.Annotations["error"] = "none"
 		return nil
-	},
+	}
+	cmd.Annotations["error"] = strings.Join(fetchErrors, "\n")
+	return fmt.Errorf("failed to fetch roles for %d user(s): %s", len(fetchErrors), strings.Join(fetchErrors, "; "))
 }
 
 func printUserRoleTable(users []UserData, roleResponses []struct {

--- a/main.go
+++ b/main.go
@@ -17,18 +17,16 @@
 package main
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"os"
-	"sync"
 
 	pb "pb/cmd"
 	"pb/pkg/analytics"
 
 	"github.com/spf13/cobra"
 )
-
-var wg sync.WaitGroup
 
 // populated at build time
 var (
@@ -58,11 +56,64 @@ var cli = &cobra.Command{
 		if os.Getenv("PB_ANALYTICS") == "disable" {
 			return
 		}
-		wg.Add(1)
 		go func() {
-			defer wg.Done()
 			analytics.PostRunAnalytics(cmd, "cli", args)
 		}()
+	},
+}
+
+func postRunAnalytics(name string) func(*cobra.Command, []string) {
+	return func(cmd *cobra.Command, args []string) {
+		if os.Getenv("PB_ANALYTICS") == "disable" {
+			return
+		}
+		go analytics.PostRunAnalytics(cmd, name, args)
+	}
+}
+
+type rootHelpCommand struct {
+	name string
+	desc string
+}
+
+type rootHelpGroup struct {
+	title    string
+	commands []rootHelpCommand
+}
+
+var rootHelpGroups = []rootHelpGroup{
+	{
+		title: "Core Commands (Query & Stream):",
+		commands: []rootHelpCommand{
+			{name: "sql", desc: "Run SQL query on a dataset"},
+			{name: "promql", desc: "PromQL queries and metrics exploration"},
+			{name: "tail", desc: "Stream live events from a dataset"},
+		},
+	},
+	{
+		title: "Data Management:",
+		commands: []rootHelpCommand{
+			{name: "dataset", desc: "Manage datasets"},
+		},
+	},
+	{
+		title: "Identity & Access:",
+		commands: []rootHelpCommand{
+			{name: "login", desc: "Login to Parseable"},
+			{name: "logout", desc: "Logout from the current Parseable profile"},
+			{name: "profile", desc: "Manage different Parseable targets"},
+			{name: "user", desc: "Manage users"},
+			{name: "role", desc: "Manage roles"},
+		},
+	},
+	{
+		title: "System Commands:",
+		commands: []rootHelpCommand{
+			{name: "status", desc: "Check connection status for the active profile"},
+			{name: "autocomplete", desc: "Generate autocomplete script"},
+			{name: "version", desc: "Print version"},
+			{name: "help", desc: "Help about any command"},
+		},
 	},
 }
 
@@ -71,16 +122,7 @@ var profile = &cobra.Command{
 	Short:             "Manage different Parseable targets",
 	Long:              "\nuse profile command to configure different Parseable instances. Each profile takes a URL and credentials.",
 	PersistentPreRunE: analytics.CheckAndCreateULID,
-	PersistentPostRun: func(cmd *cobra.Command, args []string) {
-		if os.Getenv("PB_ANALYTICS") == "disable" {
-			return
-		}
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			analytics.PostRunAnalytics(cmd, "profile", args)
-		}()
-	},
+	PersistentPostRun: postRunAnalytics("profile"),
 }
 
 var schema = &cobra.Command{
@@ -88,7 +130,7 @@ var schema = &cobra.Command{
 	Short: "Generate or create schemas for JSON data or Parseable datasets",
 	Long: `The "schema" command allows you to either:
   - Generate a schema automatically from a JSON file for analysis or integration.
-  - Create a custom schema for Parseable datasets to structure and process your data.
+	- Create a custom schema for Parseable datasets to structure and process your data.
 
 Examples:
   - To generate a schema from a JSON file:
@@ -97,16 +139,7 @@ Examples:
       pb schema create --dataset=my_dataset --config=data.json
 `,
 	PersistentPreRunE: combinedPreRun,
-	PersistentPostRun: func(cmd *cobra.Command, args []string) {
-		if os.Getenv("PB_ANALYTICS") == "disable" {
-			return
-		}
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			analytics.PostRunAnalytics(cmd, "generate", args)
-		}()
-	},
+	PersistentPostRun: postRunAnalytics("generate"),
 }
 
 var user = &cobra.Command{
@@ -114,16 +147,7 @@ var user = &cobra.Command{
 	Short:             "Manage users",
 	Long:              "\nuser command is used to manage users.",
 	PersistentPreRunE: combinedPreRun,
-	PersistentPostRun: func(cmd *cobra.Command, args []string) {
-		if os.Getenv("PB_ANALYTICS") == "disable" {
-			return
-		}
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			analytics.PostRunAnalytics(cmd, "user", args)
-		}()
-	},
+	PersistentPostRun: postRunAnalytics("user"),
 }
 
 var role = &cobra.Command{
@@ -131,16 +155,7 @@ var role = &cobra.Command{
 	Short:             "Manage roles",
 	Long:              "\nrole command is used to manage roles.",
 	PersistentPreRunE: combinedPreRun,
-	PersistentPostRun: func(cmd *cobra.Command, args []string) {
-		if os.Getenv("PB_ANALYTICS") == "disable" {
-			return
-		}
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			analytics.PostRunAnalytics(cmd, "role", args)
-		}()
-	},
+	PersistentPostRun: postRunAnalytics("role"),
 }
 
 var dataset = &cobra.Command{
@@ -148,50 +163,16 @@ var dataset = &cobra.Command{
 	Short:             "Manage datasets",
 	Long:              "\ndataset command is used to manage datasets.",
 	PersistentPreRunE: combinedPreRun,
-	PersistentPostRun: func(cmd *cobra.Command, args []string) {
-		if os.Getenv("PB_ANALYTICS") == "disable" {
-			return
-		}
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			analytics.PostRunAnalytics(cmd, "dataset", args)
-		}()
-	},
+	PersistentPostRun: postRunAnalytics("dataset"),
 }
 
-var query = &cobra.Command{
-	Use:               "query",
+var sql = &cobra.Command{
+	Use:               "sql",
 	Short:             "Run SQL query on a dataset",
 	Long:              "\nRun SQL query on a dataset. Default output format is json. Use -i flag to open interactive table view.",
+	Example:           "  pb sql run -i\n  pb sql run \"SELECT * FROM backend\" --from=1h -i",
 	PersistentPreRunE: combinedPreRun,
-	PersistentPostRun: func(cmd *cobra.Command, args []string) {
-		if os.Getenv("PB_ANALYTICS") == "disable" {
-			return
-		}
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			analytics.PostRunAnalytics(cmd, "query", args)
-		}()
-	},
-}
-
-var cluster = &cobra.Command{
-	Use:               "cluster",
-	Short:             "Cluster operations for Parseable.",
-	Long:              "\nCluster operations for Parseable cluster on Kubernetes.",
-	PersistentPreRunE: combinedPreRun,
-	PersistentPostRun: func(cmd *cobra.Command, args []string) {
-		if os.Getenv("PB_ANALYTICS") == "disable" {
-			return
-		}
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			analytics.PostRunAnalytics(cmd, "install", args)
-		}()
-	},
+	PersistentPostRun: postRunAnalytics("sql"),
 }
 
 var list = &cobra.Command{
@@ -199,16 +180,7 @@ var list = &cobra.Command{
 	Short:             "List parseable on kubernetes cluster",
 	Long:              "\nlist command is used to list Parseable oss installations.",
 	PersistentPreRunE: combinedPreRun,
-	PersistentPostRun: func(cmd *cobra.Command, args []string) {
-		if os.Getenv("PB_ANALYTICS") == "disable" {
-			return
-		}
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			analytics.PostRunAnalytics(cmd, "install", args)
-		}()
-	},
+	PersistentPostRun: postRunAnalytics("install"),
 }
 
 var show = &cobra.Command{
@@ -216,16 +188,7 @@ var show = &cobra.Command{
 	Short:             "Show outputs values defined when installing Parseable on kubernetes cluster",
 	Long:              "\nshow command is used to get values in Parseable.",
 	PersistentPreRunE: combinedPreRun,
-	PersistentPostRun: func(cmd *cobra.Command, args []string) {
-		if os.Getenv("PB_ANALYTICS") == "disable" {
-			return
-		}
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			analytics.PostRunAnalytics(cmd, "install", args)
-		}()
-	},
+	PersistentPostRun: postRunAnalytics("install"),
 }
 
 var uninstall = &cobra.Command{
@@ -233,16 +196,7 @@ var uninstall = &cobra.Command{
 	Short:             "Uninstall Parseable on kubernetes cluster",
 	Long:              "\nuninstall command is used to uninstall Parseable oss/enterprise on k8s cluster.",
 	PersistentPreRunE: combinedPreRun,
-	PersistentPostRun: func(cmd *cobra.Command, args []string) {
-		if os.Getenv("PB_ANALYTICS") == "disable" {
-			return
-		}
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			analytics.PostRunAnalytics(cmd, "uninstall", args)
-		}()
-	},
+	PersistentPostRun: postRunAnalytics("uninstall"),
 }
 
 func main() {
@@ -266,17 +220,20 @@ func main() {
 	dataset.AddCommand(pb.ListDatasetCmd)
 	dataset.AddCommand(pb.StatDatasetCmd)
 
-	query.AddCommand(pb.QueryCmd)
-	query.AddCommand(pb.PromqlCmd)
-	query.AddCommand(pb.SavedQueryList)
+	sql.AddCommand(pb.QueryCmd)
+	sql.AddCommand(pb.SaveSQLCmd)
+	sql.AddCommand(pb.SavedQueryList)
+
+	pb.PromqlCmd.PersistentPreRunE = combinedPreRun
+	pb.PromqlCmd.PersistentPostRun = postRunAnalytics("promql")
 
 	schema.AddCommand(pb.GenerateSchemaCmd)
 	schema.AddCommand(pb.CreateSchemaCmd)
 
-	cluster.AddCommand(pb.InstallOssCmd)
-	cluster.AddCommand(pb.ListOssCmd)
-	cluster.AddCommand(pb.ShowValuesCmd)
-	cluster.AddCommand(pb.UninstallOssCmd)
+	// cluster.AddCommand(pb.InstallOssCmd)
+	// cluster.AddCommand(pb.ListOssCmd)
+	// cluster.AddCommand(pb.ShowValuesCmd)
+	// cluster.AddCommand(pb.UninstallOssCmd)
 
 	list.AddCommand(pb.ListOssCmd)
 
@@ -285,12 +242,13 @@ func main() {
 	show.AddCommand(pb.ShowValuesCmd)
 
 	cli.AddCommand(profile)
-	cli.AddCommand(query)
+	cli.AddCommand(sql)
+	cli.AddCommand(pb.PromqlCmd)
 	cli.AddCommand(dataset)
 	cli.AddCommand(user)
 	cli.AddCommand(role)
 	cli.AddCommand(pb.TailCmd)
-	cli.AddCommand(cluster)
+	// cli.AddCommand(cluster)
 
 	cli.AddCommand(pb.AutocompleteCmd)
 	cli.AddCommand(pb.LoginCmd)
@@ -305,6 +263,7 @@ func main() {
 	cli.AddCommand(pb.VersionCmd)
 	// set as flag
 	cli.Flags().BoolP(versionFlag, versionFlagShort, false, "Print version")
+	cli.SetHelpFunc(renderRootHelp)
 
 	cli.CompletionOptions.HiddenDefaultCmd = true
 
@@ -312,7 +271,106 @@ func main() {
 	if err != nil {
 		os.Exit(1)
 	}
-	wg.Wait()
+}
+
+func renderRootHelp(cmd *cobra.Command, _ []string) {
+	if cmd != cli {
+		renderCommandHelp(cmd)
+		return
+	}
+
+	out := cmd.OutOrStdout()
+	fmt.Fprintln(out, "pb is the command line interface for Parseable")
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, "Usage:")
+	fmt.Fprintln(out, "  pb [command] [flags]")
+	fmt.Fprintln(out)
+
+	for _, group := range rootHelpGroups {
+		fmt.Fprintln(out, group.title)
+		for _, command := range group.commands {
+			if command.name != "help" && commandByName(cmd, command.name) == nil {
+				continue
+			}
+			fmt.Fprintf(out, "  %-12s %s\n", command.name, command.desc)
+		}
+		fmt.Fprintln(out)
+	}
+
+	if cmd.HasAvailableFlags() {
+		fmt.Fprintln(out, "Flags:")
+		var flags bytes.Buffer
+		cmd.Flags().SetOutput(&flags)
+		cmd.Flags().PrintDefaults()
+		fmt.Fprint(out, flags.String())
+		fmt.Fprintln(out)
+	}
+
+	fmt.Fprintln(out, `Use "pb [command] --help" for more information about a command.`)
+}
+
+func commandByName(cmd *cobra.Command, name string) *cobra.Command {
+	for _, child := range cmd.Commands() {
+		if child.Name() == name {
+			return child
+		}
+	}
+	return nil
+}
+
+func renderCommandHelp(cmd *cobra.Command) {
+	out := cmd.OutOrStdout()
+	desc := cmd.Long
+	if desc == "" {
+		desc = cmd.Short
+	}
+	if desc != "" {
+		fmt.Fprintln(out, desc)
+		fmt.Fprintln(out)
+	}
+
+	fmt.Fprintln(out, "Usage:")
+	fmt.Fprintf(out, "  %s\n", cmd.UseLine())
+	fmt.Fprintln(out)
+
+	if cmd.Example != "" {
+		fmt.Fprintln(out, "Examples:")
+		fmt.Fprintln(out, cmd.Example)
+		fmt.Fprintln(out)
+	}
+
+	if cmd.HasAvailableSubCommands() {
+		fmt.Fprintln(out, "Available Commands:")
+		for _, child := range cmd.Commands() {
+			if !child.IsAvailableCommand() && child.Name() != "help" {
+				continue
+			}
+			fmt.Fprintf(out, "  %-12s %s\n", child.Name(), child.Short)
+		}
+		fmt.Fprintln(out)
+	}
+
+	if cmd.HasAvailableLocalFlags() {
+		fmt.Fprintln(out, "Flags:")
+		var flags bytes.Buffer
+		cmd.LocalFlags().SetOutput(&flags)
+		cmd.LocalFlags().PrintDefaults()
+		fmt.Fprint(out, flags.String())
+		fmt.Fprintln(out)
+	}
+
+	if cmd.HasAvailableInheritedFlags() {
+		fmt.Fprintln(out, "Global Flags:")
+		var flags bytes.Buffer
+		cmd.InheritedFlags().SetOutput(&flags)
+		cmd.InheritedFlags().PrintDefaults()
+		fmt.Fprint(out, flags.String())
+		fmt.Fprintln(out)
+	}
+
+	if cmd.HasAvailableSubCommands() {
+		fmt.Fprintf(out, "Use \"%s [command] --help\" for more information about a command.\n", cmd.CommandPath())
+	}
 }
 
 // Wrapper to combine existing pre-run logic and ULID check

--- a/pkg/analytics/analytics.go
+++ b/pkg/analytics/analytics.go
@@ -142,7 +142,7 @@ func CheckAndCreateULID(_ *cobra.Command, _ []string) error {
 			fmt.Printf("could not write to config file: %v\n", err)
 			return err
 		}
-		fmt.Printf("Generated and saved new ULID: %s\n", config.ULID)
+		// fmt.Printf("Generated and saved new ULID: %s\n", config.ULID)
 	}
 
 	return nil

--- a/pkg/datasets/datasets.go
+++ b/pkg/datasets/datasets.go
@@ -1,0 +1,90 @@
+package datasets
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"pb/pkg/config"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	// TypeLogs identifies log/event datasets.
+	TypeLogs = "logs"
+	// TypeMetrics identifies metrics datasets.
+	TypeMetrics = "metrics"
+	// TypeTraces identifies traces datasets.
+	TypeTraces = "traces"
+)
+
+type Dataset struct {
+	Title         string `json:"title"`
+	DatasetType   string `json:"datasetType"`
+	DatasetFormat string `json:"datasetFormat"`
+	Ingestion     bool   `json:"ingestion"`
+}
+
+type homeResponse struct {
+	Datasets []Dataset `json:"datasets"`
+}
+
+func FetchHomeDatasets(profile config.Profile) ([]Dataset, error) {
+	reqURL, err := url.JoinPath(profile.URL, "api/prism/v1/home")
+	if err != nil {
+		return nil, err
+	}
+
+	client := &http.Client{Timeout: 15 * time.Second}
+	req, err := http.NewRequest(http.MethodGet, reqURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	authenticate(req, profile)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	var result homeResponse
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, err
+	}
+	sort.Slice(result.Datasets, func(i, j int) bool {
+		return result.Datasets[i].Title < result.Datasets[j].Title
+	})
+	return result.Datasets, nil
+}
+
+func NamesByType(items []Dataset, datasetType string) []string {
+	var names []string
+	for _, item := range items {
+		if item.DatasetType == datasetType {
+			names = append(names, item.Title)
+		}
+	}
+	sort.Strings(names)
+	return names
+}
+
+func authenticate(req *http.Request, profile config.Profile) {
+	if profile.Token != "" {
+		req.Header.Set("Authorization", "Bearer "+profile.Token)
+	} else {
+		req.SetBasicAuth(profile.Username, profile.Password)
+	}
+	req.Header.Set("Content-Type", "application/json")
+}

--- a/pkg/datasets/datasets_test.go
+++ b/pkg/datasets/datasets_test.go
@@ -1,0 +1,27 @@
+package datasets
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestNamesByTypeUsesDatasetTypeMetadata(t *testing.T) {
+	items := []Dataset{
+		{Title: "custom-name", DatasetType: TypeLogs},
+		{Title: "cpu", DatasetType: TypeMetrics},
+		{Title: "logs-looking-trace", DatasetType: TypeTraces},
+		{Title: "another-log", DatasetType: TypeLogs},
+	}
+
+	gotLogs := NamesByType(items, TypeLogs)
+	wantLogs := []string{"another-log", "custom-name"}
+	if !reflect.DeepEqual(gotLogs, wantLogs) {
+		t.Fatalf("logs mismatch\nwant: %#v\n got: %#v", wantLogs, gotLogs)
+	}
+
+	gotMetrics := NamesByType(items, TypeMetrics)
+	wantMetrics := []string{"cpu"}
+	if !reflect.DeepEqual(gotMetrics, wantMetrics) {
+		t.Fatalf("metrics mismatch\nwant: %#v\n got: %#v", wantMetrics, gotMetrics)
+	}
+}

--- a/pkg/model/datetime/datetime.go
+++ b/pkg/model/datetime/datetime.go
@@ -24,6 +24,11 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 )
 
+const localLayout = "2006-Jan-02 15:04:05"
+
+var segmentStarts = []int{0, 5, 9, 12, 15, 18}
+var segmentEnds = []int{4, 8, 11, 14, 17, 20}
+
 // Model is the model for the datetime component
 type Model struct {
 	time  time.Time
@@ -43,12 +48,27 @@ func (m *Model) ValueUtc() string {
 // SetTime sets the value of the datetime component
 func (m *Model) SetTime(t time.Time) {
 	m.time = t
-	m.input.SetValue(m.time.Format(time.DateTime))
+	m.input.SetValue(m.time.Format(localLayout))
 }
 
 // Time returns the current time of the datetime component
 func (m *Model) Time() time.Time {
 	return m.time
+}
+
+// LocalValue returns the editable local timestamp string.
+func (m *Model) LocalValue() string {
+	return m.input.Value()
+}
+
+// CursorPosition returns the cursor position in the editable timestamp.
+func (m *Model) CursorPosition() int {
+	return m.input.Position()
+}
+
+// FocusFirstSegment moves editing to the first date-time segment.
+func (m *Model) FocusFirstSegment() {
+	m.input.SetCursor(segmentStarts[0])
 }
 
 // New creates a new datetime component
@@ -93,6 +113,21 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
+		switch msg.Type {
+		case tea.KeyRight:
+			m.moveSegment(1)
+			return m, nil
+		case tea.KeyLeft:
+			m.moveSegment(-1)
+			return m, nil
+		case tea.KeyUp:
+			m.AdjustSegment(1)
+			return m, nil
+		case tea.KeyDown:
+			m.AdjustSegment(-1)
+			return m, nil
+		}
+
 		// Allow navigation keys to pass through
 		if key.Matches(msg, m.input.KeyMap.CharacterForward,
 			m.input.KeyMap.CharacterBackward,
@@ -100,7 +135,16 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 			m.input.KeyMap.WordBackward,
 			m.input.KeyMap.LineStart,
 			m.input.KeyMap.LineEnd) {
-			m.input, cmd = m.input.Update(msg)
+			switch {
+			case key.Matches(msg, m.input.KeyMap.CharacterForward):
+				m.moveSegment(1)
+				return m, nil
+			case key.Matches(msg, m.input.KeyMap.CharacterBackward):
+				m.moveSegment(-1)
+				return m, nil
+			default:
+				m.input, cmd = m.input.Update(msg)
+			}
 			return m, cmd
 		}
 		// do replace on current cursor
@@ -108,18 +152,92 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 			pos := m.input.Position()
 			oldValue := m.input.Value()
 			newValue := []rune(oldValue)
+			if pos < 0 || pos >= len(newValue) || !unicode.IsDigit(newValue[pos]) {
+				return m, nil
+			}
 			newValue[pos] = msg.Runes[0]
 			value := string(newValue)
 			local, _ := time.LoadLocation("Local")
-			newTime, err := time.ParseInLocation(time.DateTime, value, local)
+			newTime, err := time.ParseInLocation(localLayout, value, local)
 			if err == nil {
 				m.time = newTime
 				m.SetTime(newTime)
+				m.input.SetCursor(pos)
 			}
 		}
 	}
 
 	return m, nil
+}
+
+// AdjustSegment increments or decrements the currently focused date-time segment.
+func (m *Model) AdjustSegment(delta int) {
+	if delta == 0 {
+		return
+	}
+	pos := m.input.Position()
+	seg := segmentIndex(pos)
+	next := m.time
+	switch seg {
+	case 0:
+		next = next.AddDate(delta, 0, 0)
+	case 1:
+		next = addMonthsClamped(next, delta)
+	case 2:
+		next = next.AddDate(0, 0, delta)
+	case 3:
+		next = next.Add(time.Duration(delta) * time.Hour)
+	case 4:
+		next = next.Add(time.Duration(delta) * time.Minute)
+	case 5:
+		next = next.Add(time.Duration(delta) * time.Second)
+	}
+	m.SetTime(next)
+	m.input.SetCursor(segmentStarts[seg])
+}
+
+func (m *Model) moveSegment(direction int) {
+	seg := segmentIndex(m.input.Position())
+	seg += direction
+	if seg < 0 || seg >= len(segmentStarts) {
+		return
+	}
+	m.input.SetCursor(segmentStarts[seg])
+}
+
+func segmentIndex(pos int) int {
+	for i := range segmentStarts {
+		if pos >= segmentStarts[i] && pos < segmentEnds[i] {
+			return i
+		}
+	}
+	if pos < segmentStarts[0] {
+		return 0
+	}
+	for i := range segmentStarts {
+		if pos < segmentStarts[i] {
+			return i
+		}
+	}
+	return len(segmentStarts) - 1
+}
+
+func addMonthsClamped(t time.Time, months int) time.Time {
+	year, month, day := t.Date()
+	hour, minute, sec := t.Clock()
+	loc := t.Location()
+	targetMonth := int(month) + months
+	targetYear := year + (targetMonth-1)/12
+	targetMonth = (targetMonth-1)%12 + 1
+	if targetMonth <= 0 {
+		targetMonth += 12
+		targetYear--
+	}
+	lastDay := time.Date(targetYear, time.Month(targetMonth)+1, 0, hour, minute, sec, t.Nanosecond(), loc).Day()
+	if day > lastDay {
+		day = lastDay
+	}
+	return time.Date(targetYear, time.Month(targetMonth), day, hour, minute, sec, t.Nanosecond(), loc)
 }
 
 // View returns the view of the datetime component

--- a/pkg/model/promql.go
+++ b/pkg/model/promql.go
@@ -26,6 +26,7 @@ import (
 	"net/url"
 	"os"
 	"pb/pkg/config"
+	"pb/pkg/datasets"
 	"pb/pkg/ui"
 	"regexp"
 	"sort"
@@ -54,7 +55,7 @@ const (
 	promqlTimestampFullKey = "_timestamp_full"
 	promqlMetricKey        = "metric"
 	promqlValueKey         = "value"
-	promqlTimestampWidth   = 10 // matches SQL dateTimeWidth (HH:MM:SS + slack)
+	promqlTimestampWidth   = len("TIME [LOCAL]")
 	promqlAutoStep         = "auto"
 	promqlModeRange        = "range"
 	promqlModeInstant      = "instant"
@@ -71,7 +72,7 @@ const (
 const overlayDataset uint = 2
 const overlayBuilder uint = 3
 
-var PromqlNavigationMap = []string{"query", "dataset", "step", "time", "table"}
+var PromqlNavigationMap = []string{"query", "time", "dataset", "step", "table"}
 
 var (
 	promqlStepPattern      = regexp.MustCompile(`^(?:[0-9]+(?:ms|s|m|h|d|w|y))+$`)
@@ -151,6 +152,7 @@ type PromqlModel struct {
 	table         table.Model
 	query         textarea.Model
 	timeRange     TimeInputModel
+	timeRangeEdit TimeInputModel
 	profile       config.Profile
 	help          help.Model
 	status        StatusBar
@@ -316,8 +318,7 @@ func (m PromqlModel) isBothMode() bool {
 
 func NewPromqlModel(profile config.Profile, expr string, startTime, endTime time.Time, step, dataset string, instant bool) PromqlModel {
 	w, h, _ := term.GetSize(int(os.Stdout.Fd()))
-	// The legacy `pb query run -i --promql` path still passes "1m" as its
-	// cobra default. Keep the TUI default aligned with PromQL's auto step.
+	// Keep the TUI default aligned with PromQL's auto step.
 	if strings.TrimSpace(step) == "" || step == "1m" {
 		step = promqlAutoStep
 	}
@@ -327,7 +328,7 @@ func NewPromqlModel(profile config.Profile, expr string, startTime, endTime time
 	mode := initialPromqlMode(instant)
 
 	columns := []table.Column{
-		table.NewColumn(promqlTimestampKey, "TIMESTAMP", promqlTimestampWidth),
+		table.NewColumn(promqlTimestampKey, "TIME "+formatResultTimeLabel(inputs.DisplayMode()), promqlTimestampWidth),
 		table.NewFlexColumn(promqlMetricKey, "METRIC", 1),
 		table.NewColumn(promqlValueKey, "VALUE", 14),
 	}
@@ -459,7 +460,7 @@ func (m PromqlModel) Init() tea.Cmd {
 	cmds := []tea.Cmd{m.spinner.Tick}
 	if strings.TrimSpace(m.query.Value()) != "" && m.dataset != "" {
 		cmds = append(cmds, NewPromqlModeFetchTask(m.profile, m.query.Value(), m.dataset, m.step,
-			m.timeRange.StartValueUtc(), m.timeRange.EndValueUtc(), m.mode))
+			m.timeRange.StartValueUtc(), m.timeRange.EndValueUtc(), m.mode, m.timeRange.DisplayMode()))
 	}
 	if m.dataset != "" {
 		cmds = append(cmds, fetchCacheMetrics(m.profile, m.dataset))
@@ -523,7 +524,7 @@ func (m PromqlModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 						m.spinner.Tick,
 						fetchCacheMetrics(m.profile, m.dataset),
 						NewPromqlModeFetchTask(m.profile, m.query.Value(), m.dataset, m.step,
-							m.timeRange.StartValueUtc(), m.timeRange.EndValueUtc(), m.mode),
+							m.timeRange.StartValueUtc(), m.timeRange.EndValueUtc(), m.mode, m.timeRange.DisplayMode()),
 					)
 				}
 				return m, fetchCacheMetrics(m.profile, m.dataset)
@@ -932,6 +933,7 @@ func (m PromqlModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, nil
 			}
 			if msg.Type == tea.KeyEnter {
+				m.timeRange = m.timeRangeEdit
 				m.overlay = overlayNone
 				m.focusSelected()
 				m.normalizeStepForRun()
@@ -941,9 +943,9 @@ func (m PromqlModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.hasQueried = true
 				return m, tea.Batch(m.spinner.Tick,
 					NewPromqlModeFetchTask(m.profile, m.query.Value(), m.dataset, m.step,
-						m.timeRange.StartValueUtc(), m.timeRange.EndValueUtc(), m.mode))
+						m.timeRange.StartValueUtc(), m.timeRange.EndValueUtc(), m.mode, m.timeRange.DisplayMode()))
 			}
-			m.timeRange, cmd = m.timeRange.Update(msg)
+			m.timeRangeEdit, cmd = m.timeRangeEdit.Update(msg)
 			return m, cmd
 		}
 
@@ -998,6 +1000,8 @@ func (m PromqlModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		// Enter on time → open time overlay
 		if msg.Type == tea.KeyEnter && m.currentFocus() == "time" {
+			m.timeRangeEdit = m.timeRange
+			m.timeRangeEdit.SyncPreset()
 			m.overlay = overlayInputs
 			return m, nil
 		}
@@ -1025,7 +1029,7 @@ func (m PromqlModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.hasQueried = true
 			return m, tea.Batch(m.spinner.Tick,
 				NewPromqlModeFetchTask(m.profile, m.query.Value(), m.dataset, m.step,
-					m.timeRange.StartValueUtc(), m.timeRange.EndValueUtc(), m.mode))
+					m.timeRange.StartValueUtc(), m.timeRange.EndValueUtc(), m.mode, m.timeRange.DisplayMode()))
 		}
 
 		// Space on step panel cycles range/instant/both mode.
@@ -1053,7 +1057,7 @@ func (m PromqlModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.hasQueried = true
 				return m, tea.Batch(m.spinner.Tick,
 					NewPromqlModeFetchTask(m.profile, m.query.Value(), m.dataset, m.step,
-						m.timeRange.StartValueUtc(), m.timeRange.EndValueUtc(), m.mode))
+						m.timeRange.StartValueUtc(), m.timeRange.EndValueUtc(), m.mode, m.timeRange.DisplayMode()))
 			}
 			return m, nil
 		}
@@ -1138,7 +1142,7 @@ func (m *PromqlModel) runQueryFromBuilder(expr string) (PromqlModel, tea.Cmd) {
 	m.hasQueried = true
 	return *m, tea.Batch(m.spinner.Tick,
 		NewPromqlModeFetchTask(m.profile, m.query.Value(), m.dataset, m.step,
-			m.timeRange.StartValueUtc(), m.timeRange.EndValueUtc(), m.mode))
+			m.timeRange.StartValueUtc(), m.timeRange.EndValueUtc(), m.mode, m.timeRange.DisplayMode()))
 }
 
 func (m *PromqlModel) openBuilderOverlay() tea.Cmd {
@@ -1366,12 +1370,9 @@ func (m PromqlModel) View() string {
 	bottomHeight := lipgloss.Height(bottomView)
 
 	topH := 13
-	sidebarW := 30
+	sidebarW := sqlControlsMinWidth
 	if m.width >= 140 {
-		sidebarW = 34
-	}
-	if m.width < 100 {
-		sidebarW = 26
+		sidebarW = sqlControlsMinWidth + 3
 	}
 	// editorW reserves 1 col for the horizontal gap between editor
 	// and sidebar so the two `│` borders aren't flush against each
@@ -1408,33 +1409,28 @@ func (m PromqlModel) View() string {
 	editorFocused := m.currentFocus() == "query"
 	editorPane := renderPromqlEditorPane(editorBody, editorW, topH, editorFocused, m.queryMode == "builder")
 
-	rangeMode := m.mode
 	stepHi := m.currentFocus() == "step"
-	dsHi := m.currentFocus() == "dataset"
 	dataset := m.dataset
 	if dataset == "" {
 		dataset = "select-dataset"
 	}
-	timeHi := m.currentFocus() == "time"
-	// Two stacked sidebar boxes. Borders touch — same zero-gap join
-	// used between the top section and the results pane.
-	// Controls (7 rows) + Date (6 rows) = 13 = topH.
 	// When step is focused, pass the live textinput View() so its cursor is visible.
 	stepDisplay := m.step
 	if stepHi {
 		stepDisplay = m.stepInput.View()
 	}
-	controlsBox := renderPromqlControlsBox(
-		dataset, stepDisplay, rangeMode,
-		sidebarW, 7,
-		dsHi, stepHi, m.isInstantMode(),
+	sidebarPane := renderPromqlControlsPane(
+		formatSQLControlTime(m.timeRange.start.Time(), m.timeRange.DisplayMode()),
+		formatSQLControlTime(m.timeRange.end.Time(), m.timeRange.DisplayMode()),
+		dataset,
+		stepDisplay,
+		m.mode,
+		sidebarW,
+		topH,
+		m.currentFocus(),
+		m.isInstantMode(),
+		m.timeRange.DisplayMode(),
 	)
-	dateBox := renderPromqlDateBox(
-		m.timeRange.start.Value(), m.timeRange.end.Value(),
-		sidebarW, 6,
-		timeHi, m.isInstantMode(),
-	)
-	sidebarPane := lipgloss.JoinVertical(lipgloss.Left, controlsBox, dateBox)
 
 	gap := lipgloss.NewStyle().Width(1).Height(topH).Render("")
 	topSection := lipgloss.JoinHorizontal(lipgloss.Top, editorPane, gap, sidebarPane)
@@ -1515,7 +1511,7 @@ func (m PromqlModel) View() string {
 	case overlayNone:
 		mainView = body
 	case overlayInputs:
-		timeView := m.timeRange.View()
+		timeView := m.timeRangeEdit.View()
 		mainView = lipgloss.Place(m.width, m.height-bottomHeight,
 			lipgloss.Center, lipgloss.Center, timeView,
 			lipgloss.WithWhitespaceChars(" "),
@@ -1557,25 +1553,12 @@ func renderPromqlResultsPane(body string, width, height int, focused bool, title
 	if innerH < 3 {
 		innerH = 3
 	}
-
-	left := lipgloss.NewStyle().Foreground(titleFg).Bold(focused).Render(title)
-	gap := innerW - lipgloss.Width(left) - lipgloss.Width(right) - 2
-	if gap < 1 {
-		gap = 1
-	}
-	titleRow := lipgloss.NewStyle().Width(innerW).Padding(0, 1).Render(
-		left + strings.Repeat(" ", gap) + right,
-	)
-	bodyPane := lipgloss.NewStyle().
-		Width(innerW).
-		Height(innerH-1).
-		Padding(0, 1).
-		Render(body)
-	stack := lipgloss.JoinVertical(lipgloss.Left, titleRow, bodyPane)
-	return lipgloss.NewStyle().
-		Border(lipgloss.NormalBorder()).
-		BorderForeground(borderColor).
-		Render(stack)
+	borderStyle := lipgloss.NewStyle().Foreground(borderColor)
+	titleStyle := lipgloss.NewStyle().Foreground(titleFg).Bold(focused)
+	lines := []string{promqlPaneRule("┌", "┐", title, right, width, borderStyle, titleStyle)}
+	lines = append(lines, paneBodyLines(body, width, innerH, borderStyle)...)
+	lines = append(lines, borderStyle.Render("└"+strings.Repeat("─", innerW)+"┘"))
+	return lipgloss.JoinVertical(lipgloss.Left, lines...)
 }
 
 func renderPromqlEditorPane(body string, width, height int, focused, builder bool) string {
@@ -1595,8 +1578,6 @@ func renderPromqlEditorPane(body string, width, height int, focused, builder boo
 		innerH = 3
 	}
 
-	left := lipgloss.NewStyle().Foreground(titleFg).Bold(focused).Render("EDITOR")
-
 	activeStyle := lipgloss.NewStyle().Foreground(p.Active).Bold(true)
 	idle := lipgloss.NewStyle().Foreground(p.Faint)
 	sepStyle := lipgloss.NewStyle().Foreground(p.Faint)
@@ -1608,132 +1589,134 @@ func renderPromqlEditorPane(body string, width, height int, focused, builder boo
 		right = activeStyle.Render("Code") + sep + idle.Render("Builder")
 	}
 
-	gap := innerW - lipgloss.Width(left) - lipgloss.Width(right) - 2
-	if gap < 1 {
-		gap = 1
-	}
-	titleRow := lipgloss.NewStyle().Width(innerW).Padding(0, 1).Render(
-		left + strings.Repeat(" ", gap) + right,
-	)
-	spacer := lipgloss.NewStyle().Width(innerW).Render("")
-	bodyPane := lipgloss.NewStyle().
-		Width(innerW).
-		Height(innerH-2).
-		Padding(0, 1).
-		Render(body)
-	stack := lipgloss.JoinVertical(lipgloss.Left, titleRow, spacer, bodyPane)
-	return lipgloss.NewStyle().
-		Border(lipgloss.NormalBorder()).
-		BorderForeground(borderColor).
-		Render(stack)
+	borderStyle := lipgloss.NewStyle().Foreground(borderColor)
+	titleStyle := lipgloss.NewStyle().Foreground(titleFg).Bold(focused)
+	lines := []string{promqlPaneRule("┌", "┐", "EDITOR", right, width, borderStyle, titleStyle)}
+	lines = append(lines, paneBodyLines(body, width, innerH, borderStyle)...)
+	lines = append(lines, borderStyle.Render("└"+strings.Repeat("─", innerW)+"┘"))
+	return lipgloss.JoinVertical(lipgloss.Left, lines...)
 }
 
-// sidebarStyles returns the shared label/value/rail styles used by
-// the controls and date sidebar boxes.
-func sidebarStyles() (dim, val, hi lipgloss.Style, rail string) {
-	p := ui.Active
-	dim = lipgloss.NewStyle().Foreground(p.Faint)
-	val = lipgloss.NewStyle().Foreground(p.Body)
-	hi = lipgloss.NewStyle().Foreground(p.Active).Bold(true)
-	rail = lipgloss.NewStyle().Background(p.Active).Render(" ")
-	return
-}
-
-func renderPromqlControlsBox(dataset, step, mode string, width, height int, datasetHi, stepHi, instant bool) string {
-	p := ui.Active
-	innerW := width - 2
-	if innerW < 4 {
-		innerW = 4
+func promqlPaneRule(left, right, title, rightText string, width int, borderStyle, titleStyle lipgloss.Style) string {
+	if width < 2 {
+		width = 2
 	}
-	innerH := height - 2
-	if innerH < 1 {
-		innerH = 1
+	if title == "" {
+		return borderStyle.Render(left + strings.Repeat("─", width-2) + right)
 	}
-	dim, val, hi, rail := sidebarStyles()
-	prefix := func(active bool) string {
-		if active {
-			return rail + " "
+	label := " " + title + " "
+	prefix := left + "──"
+	rightLabel := ""
+	if strings.TrimSpace(rightText) != "" {
+		rightLabel = " " + rightText + " "
+	}
+	fill := width - lipgloss.Width(prefix) - lipgloss.Width(label) - lipgloss.Width(rightLabel) - lipgloss.Width(right)
+	if fill < 0 {
+		fill = 0
+		titleW := width - lipgloss.Width(prefix) - lipgloss.Width(rightLabel) - lipgloss.Width(right) - 2
+		if titleW < 1 {
+			titleW = 1
 		}
-		return "  "
+		label = " " + ui.Truncate(title, titleW) + " "
 	}
-	dLabel := dim
-	if datasetHi {
-		dLabel = hi
-	}
-	sLabel := dim
-	if stepHi {
-		sLabel = hi
-	}
-	// When step is focused, `step` is already the textinput View() string
-	// (cursor included); render it directly to avoid stripping the cursor.
-	stepVal := val.Render(step)
-	if stepHi {
-		stepVal = step
-	}
-	// In instant mode step is irrelevant — show it greyed out with a dash.
-	if instant {
-		sLabel = lipgloss.NewStyle().Foreground(p.Ghost)
-		stepVal = lipgloss.NewStyle().Foreground(p.Ghost).Render("—")
-	}
-	modeLabel := sLabel
-	if stepHi && instant {
-		modeLabel = hi
-	}
-	lines := []string{
-		prefix(datasetHi) + dLabel.Render("DATASET"),
-		prefix(datasetHi) + val.Render(dataset),
-		"",
-		prefix(stepHi) + sLabel.Render("STEP  ") + stepVal,
-		prefix(stepHi) + modeLabel.Render("MODE  ") + val.Render(mode),
-	}
-	body := lipgloss.NewStyle().
-		Width(innerW).
-		Height(innerH).
-		Render(lipgloss.JoinVertical(lipgloss.Left, lines...))
-	return lipgloss.NewStyle().
-		Border(lipgloss.NormalBorder()).
-		BorderForeground(p.Border).
-		Render(body)
+	return borderStyle.Render(prefix) + titleStyle.Render(label) + borderStyle.Render(strings.Repeat("─", fill)) + rightLabel + borderStyle.Render(right)
 }
 
-func renderPromqlDateBox(start, end string, width, height int, timeHi, instant bool) string {
+func renderPromqlControlsPane(start, end, dataset, step, mode string, width, height int, focusedOn string, instant bool, displayMode TimeDisplayMode) string {
 	p := ui.Active
 	innerW := width - 2
 	if innerW < 4 {
 		innerW = 4
 	}
-	innerH := height - 2
-	if innerH < 1 {
-		innerH = 1
+	valW := innerW - 2
+	if valW < 4 {
+		valW = 4
 	}
-	dim, val, hi, rail := sidebarStyles()
-	prefix := "  "
-	if timeHi {
-		prefix = rail + " "
+
+	rail := lipgloss.NewStyle().Background(p.Active).Render(" ")
+	dim := lipgloss.NewStyle().Foreground(p.Faint)
+	body := lipgloss.NewStyle().Foreground(p.Body)
+	active := lipgloss.NewStyle().Foreground(p.Active).Bold(true)
+	ghost := lipgloss.NewStyle().Foreground(p.Ghost)
+
+	sectionFocused := focusedOn == "time" || focusedOn == "dataset" || focusedOn == "step"
+	borderColor := p.Border
+	if sectionFocused {
+		borderColor = p.BorderHi
 	}
-	label := dim
-	if timeHi {
-		label = hi
+	borderStyle := lipgloss.NewStyle().Foreground(borderColor)
+	titleStyle := func(name string) lipgloss.Style {
+		if focusedOn == name {
+			return lipgloss.NewStyle().Foreground(p.Accent).Bold(true)
+		}
+		return lipgloss.NewStyle().Foreground(p.Faint)
 	}
-	lines := []string{}
+	row := func(focus, label, value string, valueStyle lipgloss.Style) []string {
+		prefix := "  "
+		labelStyle := dim
+		if focusedOn == focus {
+			prefix = rail + " "
+			labelStyle = active
+		}
+		return []string{
+			prefix + labelStyle.Render(label),
+			prefix + valueStyle.Render(ui.Truncate(value, valW)),
+		}
+	}
+
+	timeLines := []string{}
 	if !instant {
-		lines = append(lines,
-			prefix+label.Render("FROM"),
-			prefix+val.Render(start),
-		)
+		timeLines = append(timeLines, row("time", "FROM", start, body)...)
 	}
-	lines = append(lines,
-		prefix+label.Render("TO"),
-		prefix+val.Render(end),
-	)
-	body := lipgloss.NewStyle().
-		Width(innerW).
-		Height(innerH).
-		Render(lipgloss.JoinVertical(lipgloss.Left, lines...))
-	return lipgloss.NewStyle().
-		Border(lipgloss.NormalBorder()).
-		BorderForeground(p.Border).
-		Render(body)
+	timeLines = append(timeLines, row("time", "TO", end, body)...)
+	timeLines = append(timeLines, "")
+
+	datasetPrefix := "  "
+	datasetStyle := body
+	if focusedOn == "dataset" {
+		datasetPrefix = rail + " "
+		datasetStyle = active
+	}
+	datasetLines := []string{
+		datasetPrefix + datasetStyle.Render(ui.Truncate(dataset, valW)),
+		"",
+	}
+
+	stepPrefix := "  "
+	stepLabel := dim
+	if focusedOn == "step" {
+		stepPrefix = rail + " "
+		stepLabel = active
+	}
+	stepValue := body.Render(ui.Truncate(step, valW-lipgloss.Width("STEP ")))
+	modeValue := body.Render(ui.Truncate(mode, valW-lipgloss.Width("MODE ")))
+	if focusedOn == "step" {
+		stepValue = step
+	}
+	if instant {
+		stepLabel = ghost
+		stepValue = ghost.Render("—")
+	}
+	queryLines := []string{
+		stepPrefix + stepLabel.Render("STEP ") + stepValue,
+		stepPrefix + stepLabel.Render("MODE ") + modeValue,
+	}
+
+	querySectionH := height - 4 - len(timeLines) - len(datasetLines)
+	if querySectionH < len(queryLines) {
+		querySectionH = len(queryLines)
+	}
+
+	lines := []string{
+		paneRule("┌", "┐", "TIME RANGE "+formatResultTimeLabel(displayMode), width, borderStyle, titleStyle("time")),
+	}
+	lines = append(lines, paneBodyLines(lipgloss.JoinVertical(lipgloss.Left, timeLines...), width, len(timeLines), borderStyle)...)
+	lines = append(lines, paneRule("├", "┤", "DATASET", width, borderStyle, titleStyle("dataset")))
+	lines = append(lines, paneBodyLines(lipgloss.JoinVertical(lipgloss.Left, datasetLines...), width, len(datasetLines), borderStyle)...)
+	lines = append(lines, paneRule("├", "┤", "QUERY", width, borderStyle, titleStyle("step")))
+	lines = append(lines, paneBodyLines(lipgloss.JoinVertical(lipgloss.Left, queryLines...), width, querySectionH, borderStyle)...)
+	lines = append(lines, borderStyle.Render("└"+strings.Repeat("─", innerW)+"┘"))
+	return lipgloss.JoinVertical(lipgloss.Left, lines...)
 }
 
 // buildPromqlBottomBar renders shortcuts, divider, and connection status.
@@ -1817,10 +1800,15 @@ func promqlKeysForFocus(m PromqlModel) []ui.KeyHint {
 			{Key: "<esc>", Label: "Cancel"},
 		}
 	case overlayInputs:
+		upDownLabel := "Adjust"
+		if m.timeRangeEdit.currentFocus() == "list" {
+			upDownLabel = "Preset"
+		} else if m.timeRangeEdit.currentFocus() == "display" {
+			upDownLabel = "Display time"
+		}
 		return []ui.KeyHint{
-			{Key: "<↑/↓>", Label: "Preset"},
-			{Key: "<tab>", Label: "Field"},
-			{Key: "<ctrl-{>", Label: "End → now"},
+			{Key: "<↑/↓>", Label: upDownLabel},
+			{Key: "<tab>", Label: "Switch pane"},
 			{Key: "<enter>", Label: "Apply"},
 			{Key: "<esc>", Label: "Cancel"},
 		}
@@ -1986,7 +1974,7 @@ func (m *PromqlModel) updateTableColumns(_, valueWidth int) {
 		valueWidth = len(promqlValueKey)
 	}
 	columns := []table.Column{
-		table.NewColumn(promqlTimestampKey, "TIMESTAMP", promqlTimestampWidth),
+		table.NewColumn(promqlTimestampKey, "TIME "+formatResultTimeLabel(m.timeRange.DisplayMode()), promqlTimestampWidth),
 		table.NewFlexColumn(promqlMetricKey, "METRIC", 1).WithFiltered(true),
 		table.NewColumn(promqlValueKey, "VALUE", valueWidth).WithFiltered(true),
 	}
@@ -2102,10 +2090,10 @@ func NewPromqlFetchTask(profile config.Profile, expr, dataset, step, startTime, 
 	if instant {
 		mode = promqlModeInstant
 	}
-	return NewPromqlModeFetchTask(profile, expr, dataset, step, startTime, endTime, mode)
+	return NewPromqlModeFetchTask(profile, expr, dataset, step, startTime, endTime, mode, TimeDisplayLocal)
 }
 
-func NewPromqlModeFetchTask(profile config.Profile, expr, dataset, step, startTime, endTime, mode string) tea.Cmd {
+func NewPromqlModeFetchTask(profile config.Profile, expr, dataset, step, startTime, endTime, mode string, displayMode TimeDisplayMode) tea.Cmd {
 	return func() (msg tea.Msg) {
 		res := PromqlFetchData{status: fetchErr}
 		defer func() {
@@ -2126,8 +2114,8 @@ func NewPromqlModeFetchTask(profile config.Profile, expr, dataset, step, startTi
 				res.errMsg = err.Error()
 				return res
 			}
-			rows, seriesCount, metricWidth, valueWidth := promqlResultToRows(instantResult)
-			chartRows, _, _, _ := promqlResultToRows(rangeResult)
+			rows, seriesCount, metricWidth, valueWidth := promqlResultToRows(instantResult, displayMode)
+			chartRows, _, _, _ := promqlResultToRows(rangeResult, displayMode)
 			res.status = fetchOk
 			res.resultType = instantResult.Data.ResultType
 			res.chartResult = rangeResult.Data.ResultType
@@ -2145,7 +2133,7 @@ func NewPromqlModeFetchTask(profile config.Profile, expr, dataset, step, startTi
 			return res
 		}
 
-		rows, seriesCount, metricWidth, valueWidth := promqlResultToRows(result)
+		rows, seriesCount, metricWidth, valueWidth := promqlResultToRows(result, displayMode)
 		res.status = fetchOk
 		res.resultType = result.Data.ResultType
 		if result.Data.ResultType == "matrix" {
@@ -2244,7 +2232,7 @@ func promqlModelFetch(profile config.Profile, path string, params url.Values) ([
 
 // ─── data conversion ──────────────────────────────────────────────────────────
 
-func promqlResultToRows(result promqlRespModel) (rows []table.Row, seriesCount, metricWidth, valueWidth int) {
+func promqlResultToRows(result promqlRespModel, displayMode TimeDisplayMode) (rows []table.Row, seriesCount, metricWidth, valueWidth int) {
 	metricWidth = len(promqlMetricKey)
 	valueWidth = 14
 
@@ -2261,7 +2249,7 @@ func promqlResultToRows(result promqlRespModel) (rows []table.Row, seriesCount, 
 		switch result.Data.ResultType {
 		case "vector":
 			if len(series.Value) == 2 {
-				tsFull := promqlModelFormatTS(series.Value[0])
+				tsFull := promqlModelFormatTS(series.Value[0], displayMode)
 				ts := trimTimestampToHMS(tsFull)
 				val := fmt.Sprintf("%v", series.Value[1])
 				if len(val) > valueWidth {
@@ -2277,7 +2265,7 @@ func promqlResultToRows(result promqlRespModel) (rows []table.Row, seriesCount, 
 		case "matrix":
 			for _, pt := range series.Values {
 				if len(pt) == 2 {
-					tsFull := promqlModelFormatTS(pt[0])
+					tsFull := promqlModelFormatTS(pt[0], displayMode)
 					ts := trimTimestampToHMS(tsFull)
 					val := fmt.Sprintf("%v", pt[1])
 					if len(val) > valueWidth {
@@ -2316,14 +2304,21 @@ func promqlModelFormatLabels(m map[string]string) string {
 	return fmt.Sprintf("%s{%s}", name, strings.Join(labels, ", "))
 }
 
-func promqlModelFormatTS(v any) string {
+func promqlModelFormatTS(v any, displayMode TimeDisplayMode) string {
 	if f, ok := v.(float64); ok {
 		sec, frac := math.Modf(f)
 		nsec := int64(frac * float64(time.Second))
-		return time.Unix(int64(sec), nsec).In(time.Local).Format("2006-01-02T15:04:05-07:00")
+		t := time.Unix(int64(sec), nsec)
+		if displayMode == TimeDisplayUTC {
+			return t.UTC().Format("2006-01-02T15:04:05Z")
+		}
+		return t.In(time.Local).Format("2006-01-02T15:04:05-07:00")
 	}
 	if s, ok := v.(string); ok {
 		if t, parsed := parsePromqlChartTime(s); parsed {
+			if displayMode == TimeDisplayUTC {
+				return t.UTC().Format("2006-01-02T15:04:05Z")
+			}
 			return t.Format("2006-01-02T15:04:05-07:00")
 		}
 	}
@@ -2564,68 +2559,15 @@ func (m PromqlModel) renderBuilder() string {
 
 // ─── builder async commands ───────────────────────────────────────────────────
 
-// fetchMetricDatasets fetches all streams and keeps those whose name contains "metrics"
-// (case-insensitive). Falls back to all datasets when none match.
+// fetchMetricDatasets fetches Prism's dataset metadata and keeps metric
+// datasets, matching the web UI's Metrics section.
 func fetchMetricDatasets(profile config.Profile) tea.Cmd {
 	return func() tea.Msg {
-		reqURL, err := url.JoinPath(profile.URL, "api/v1/logstream")
+		items, err := datasets.FetchHomeDatasets(profile)
 		if err != nil {
 			return datasetListMsg{errMsg: err.Error()}
 		}
-		client := &http.Client{Timeout: 15 * time.Second}
-		req, err := http.NewRequest("GET", reqURL, nil)
-		if err != nil {
-			return datasetListMsg{errMsg: err.Error()}
-		}
-		if profile.Token != "" {
-			req.Header.Set("Authorization", "Bearer "+profile.Token)
-		} else {
-			req.SetBasicAuth(profile.Username, profile.Password)
-		}
-		resp, err := client.Do(req)
-		if err != nil {
-			return datasetListMsg{errMsg: err.Error()}
-		}
-		defer resp.Body.Close()
-		body, _ := io.ReadAll(resp.Body)
-
-		var items []struct {
-			Name       string `json:"name"`
-			StreamType string `json:"stream_type"`
-		}
-		if err := json.Unmarshal(body, &items); err != nil {
-			return datasetListMsg{errMsg: err.Error()}
-		}
-
-		// Prefer server-side stream_type (matches exactly what the UI shows).
-		// Fall back to name-contains-"metrics" only for servers that don't
-		// return stream_type — never return everything unfiltered.
-		hasType := false
-		for _, item := range items {
-			if item.StreamType != "" {
-				hasType = true
-				break
-			}
-		}
-		var all, typed []string
-		for _, item := range items {
-			all = append(all, item.Name)
-			if hasType {
-				if item.StreamType == "Metrics" {
-					typed = append(typed, item.Name)
-				}
-			} else {
-				if strings.Contains(strings.ToLower(item.Name), "metrics") {
-					typed = append(typed, item.Name)
-				}
-			}
-		}
-		datasets := typed
-		if len(datasets) == 0 {
-			datasets = all
-		}
-		sort.Strings(datasets)
-		return datasetListMsg{datasets: datasets}
+		return datasetListMsg{datasets: datasets.NamesByType(items, datasets.TypeMetrics)}
 	}
 }
 
@@ -2983,6 +2925,13 @@ func formatChartTime12h(t time.Time) string {
 	return t.Format("3:04pm")
 }
 
+func chartDisplayTime(t time.Time, mode TimeDisplayMode) time.Time {
+	if mode == TimeDisplayUTC {
+		return t.UTC()
+	}
+	return t.In(time.Local)
+}
+
 func formatChartRangeTime(t time.Time, duration time.Duration) string {
 	if isDateChartRange(duration) {
 		return t.Format("Jan 2, 2006")
@@ -3017,8 +2966,8 @@ func (m PromqlModel) chartTimeRangeTitle() string {
 	}
 	duration := m.chartSelectedDuration(first, last)
 	return fmt.Sprintf("📊 %s → %s",
-		formatChartRangeTime(first, duration),
-		formatChartRangeTime(last, duration))
+		formatChartRangeTime(chartDisplayTime(first, m.timeRange.DisplayMode()), duration),
+		formatChartRangeTime(chartDisplayTime(last, m.timeRange.DisplayMode()), duration))
 }
 
 func (m PromqlModel) chartSelectedDuration(fallbackStart, fallbackEnd time.Time) time.Duration {
@@ -3501,13 +3450,14 @@ func (m PromqlModel) drawChartXAxisLabels(chart *timeserieslinechart.Model, poin
 	for i := 0; i < chartXAxisLabelCount; i++ {
 		ratio := float64(i) / float64(chartXAxisLabelCount-1)
 		t := first.Add(time.Duration(ratio * float64(total)))
-		label := formatChartAxisLabel(t, duration, chart.GraphWidth())
+		label := formatChartAxisLabel(t, duration, chart.GraphWidth(), m.timeRange.DisplayMode())
 		x := chart.Origin().X + int(math.Round(ratio*float64(chart.GraphWidth())))
 		placeChartCanvasLabel(chart, labelY, x, label, labelStyle)
 	}
 }
 
-func formatChartAxisLabel(t time.Time, duration time.Duration, graphWidth int) string {
+func formatChartAxisLabel(t time.Time, duration time.Duration, graphWidth int, displayMode TimeDisplayMode) string {
+	t = chartDisplayTime(t, displayMode)
 	if isDateChartRange(duration) && graphWidth < chartXAxisLabelCount*12 {
 		return t.Format("Jan 2")
 	}
@@ -3540,7 +3490,8 @@ func (m PromqlModel) renderChartInspector(width int, points []timeserieslinechar
 	p := ui.Active
 	point := points[idx]
 	dot := lipgloss.NewStyle().Foreground(p.Accent).Render("●")
-	timeText := lipgloss.NewStyle().Foreground(p.Body).Render(point.Time.Format("3:04 PM, Jan 2, 2006"))
+	displayTime := chartDisplayTime(point.Time, m.timeRange.DisplayMode())
+	timeText := lipgloss.NewStyle().Foreground(p.Body).Render(displayTime.Format("3:04 PM, Jan 2, 2006"))
 	separator := lipgloss.NewStyle().Foreground(p.Faint).Render("|")
 	name := lipgloss.NewStyle().Foreground(p.Faint).Render("value")
 	value := lipgloss.NewStyle().Foreground(p.Body).Bold(true).Render(formatCompactChartValue(point.Value))

--- a/pkg/model/promql_test.go
+++ b/pkg/model/promql_test.go
@@ -269,14 +269,60 @@ func TestFormatChartTime12h(t *testing.T) {
 	}
 }
 
+func TestChartTimeRangeTitleUsesDisplayMode(t *testing.T) {
+	oldLocal := time.Local
+	time.Local = time.FixedZone("IST", 5*60*60+30*60)
+	defer func() { time.Local = oldLocal }()
+
+	firstUTC := time.Date(2026, 1, 2, 9, 0, 0, 0, time.UTC)
+	lastUTC := time.Date(2026, 1, 2, 9, 10, 0, 0, time.UTC)
+	rows := []table.Row{
+		table.NewRow(table.RowData{
+			promqlTimestampFullKey: firstUTC.Format(time.RFC3339),
+			promqlMetricKey:        `cpu_usage{host.arch="amd64"}`,
+			promqlValueKey:         "1",
+		}),
+		table.NewRow(table.RowData{
+			promqlTimestampFullKey: lastUTC.Format(time.RFC3339),
+			promqlMetricKey:        `cpu_usage{host.arch="amd64"}`,
+			promqlValueKey:         "2",
+		}),
+	}
+
+	localModel := PromqlModel{dataRows: rows}
+	localModel.timeRange.SetDisplayMode(TimeDisplayLocal)
+	if got, want := localModel.chartTimeRangeTitle(), "📊 2:30pm → 2:40pm"; got != want {
+		t.Fatalf("local title = %q, want %q", got, want)
+	}
+
+	utcModel := PromqlModel{dataRows: rows}
+	utcModel.timeRange.SetDisplayMode(TimeDisplayUTC)
+	if got, want := utcModel.chartTimeRangeTitle(), "📊 9:00am → 9:10am"; got != want {
+		t.Fatalf("utc title = %q, want %q", got, want)
+	}
+}
+
 func TestPromqlModelFormatTSUsesLocalTime(t *testing.T) {
 	oldLocal := time.Local
 	time.Local = time.FixedZone("IST", 5*60*60+30*60)
 	defer func() { time.Local = oldLocal }()
 
 	utc := time.Date(2026, 1, 2, 10, 0, 0, 0, time.UTC)
-	got := promqlModelFormatTS(float64(utc.Unix()))
+	got := promqlModelFormatTS(float64(utc.Unix()), TimeDisplayLocal)
 	want := "2026-01-02T15:30:00+05:30"
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestPromqlModelFormatTSUsesUTC(t *testing.T) {
+	oldLocal := time.Local
+	time.Local = time.FixedZone("IST", 5*60*60+30*60)
+	defer func() { time.Local = oldLocal }()
+
+	utc := time.Date(2026, 1, 2, 10, 0, 0, 0, time.UTC)
+	got := promqlModelFormatTS(float64(utc.Unix()), TimeDisplayUTC)
+	want := "2026-01-02T10:00:00Z"
 	if got != want {
 		t.Fatalf("got %q, want %q", got, want)
 	}

--- a/pkg/model/query.go
+++ b/pkg/model/query.go
@@ -616,9 +616,6 @@ func (m QueryModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 
 			if msg.Type == tea.KeyEnter && m.currentFocus() == "columns" {
-				if !m.columnsDrawerOpen {
-					return m, m.toggleColumnsDrawer()
-				}
 				m.insertSelectedColumn()
 				return m, nil
 			}
@@ -782,7 +779,7 @@ func (m QueryModel) View() string {
 		bodyH = 12
 	}
 	const editorH = 12
-	fullHeightControls := m.columnsDrawerOpen && !m.columnsLoading && len(m.filteredColumns) > 0
+	fullHeightControls := m.columnsDrawerOpen
 
 	// editorW reserves 1 col for the horizontal gap between editor
 	// and sidebar, so the two │ borders aren't flush against each other.
@@ -1460,7 +1457,11 @@ func ensureDefaultSQLLimit(query string) string {
 		trimmed = strings.TrimSpace(strings.TrimSuffix(trimmed, ";"))
 		suffix = ";"
 	}
-	return trimmed + " LIMIT 500" + suffix
+	separator := " "
+	if endsInSQLLineComment(trimmed) {
+		separator = "\n"
+	}
+	return trimmed + separator + "LIMIT 500" + suffix
 }
 
 func hasTopLevelSQLLimit(query string) bool {
@@ -1489,6 +1490,28 @@ func hasTopLevelSQLLimit(query string) bool {
 				}
 				i++
 			}
+		case '-':
+			if i+1 < len(query) && query[i+1] == '-' {
+				i += 2
+				for i < len(query) && query[i] != '\n' {
+					i++
+				}
+				continue
+			}
+			i++
+		case '/':
+			if i+1 < len(query) && query[i+1] == '*' {
+				i += 2
+				for i+1 < len(query) {
+					if query[i] == '*' && query[i+1] == '/' {
+						i += 2
+						break
+					}
+					i++
+				}
+				continue
+			}
+			i++
 		case '(':
 			depth++
 			i++
@@ -1517,6 +1540,66 @@ func isSQLLimitTokenAt(query string, idx int) bool {
 	}
 	next := idx + len(token)
 	return next >= len(query) || !isIdentChar(rune(query[next]))
+}
+
+func endsInSQLLineComment(query string) bool {
+	inSingleQuote := false
+	inDoubleQuote := false
+	inBlockComment := false
+	lineCommentStart := -1
+
+	for i := 0; i < len(query); i++ {
+		if inSingleQuote {
+			if query[i] == '\'' {
+				if i+1 < len(query) && query[i+1] == '\'' {
+					i++
+					continue
+				}
+				inSingleQuote = false
+			}
+			continue
+		}
+		if inDoubleQuote {
+			if query[i] == '"' {
+				if i+1 < len(query) && query[i+1] == '"' {
+					i++
+					continue
+				}
+				inDoubleQuote = false
+			}
+			continue
+		}
+		if inBlockComment {
+			if query[i] == '*' && i+1 < len(query) && query[i+1] == '/' {
+				inBlockComment = false
+				i++
+			}
+			continue
+		}
+
+		switch query[i] {
+		case '\'':
+			inSingleQuote = true
+		case '"':
+			inDoubleQuote = true
+		case '-':
+			if i+1 < len(query) && query[i+1] == '-' {
+				lineCommentStart = i
+				i++
+			}
+		case '/':
+			if i+1 < len(query) && query[i+1] == '*' {
+				inBlockComment = true
+				i++
+			}
+		case '\n', '\r':
+			lineCommentStart = -1
+		}
+	}
+	if lineCommentStart < 0 {
+		return false
+	}
+	return strings.TrimSpace(query[lineCommentStart+2:]) != ""
 }
 
 // parseableASCIIArt is the block-letter wordmark shown in the empty
@@ -1613,6 +1696,234 @@ func isIdentChar(r rune) bool {
 	return (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '_'
 }
 
+func quoteUnsafeSQLTableNames(query string) string {
+	var result strings.Builder
+	i, n := 0, len(query)
+	for i < n {
+		switch query[i] {
+		case '\'':
+			i = copySQLStringLiteral(&result, query, i)
+		case '"':
+			i = copySQLQuotedIdentifier(&result, query, i)
+		default:
+			if isSQLTableClauseAt(query, i) {
+				j := i + sqlTableClauseLen(query, i)
+				result.WriteString(query[i:j])
+				i = j
+
+				for i < n && isSQLSpace(query[i]) {
+					result.WriteByte(query[i])
+					i++
+				}
+				if i >= n {
+					continue
+				}
+				if query[i] == '"' || query[i] == '\'' || query[i] == '(' {
+					continue
+				}
+
+				start := i
+				for i < n && !isSQLTableTokenEnd(query[i]) {
+					i++
+				}
+				tableName := query[start:i]
+				if shouldQuoteSQLTableName(tableName) {
+					result.WriteByte('"')
+					result.WriteString(strings.ReplaceAll(tableName, `"`, `""`))
+					result.WriteByte('"')
+				} else {
+					result.WriteString(tableName)
+				}
+				continue
+			}
+			result.WriteByte(query[i])
+			i++
+		}
+	}
+	return result.String()
+}
+
+// quoteUnsafeSQLFieldNames matches the command-mode SQL normalizer: dotted
+// columns like service.name and mixed-case columns like StatusCode must be
+// quoted for DataFusion to read them as Parseable field names.
+func quoteUnsafeSQLFieldNames(query string) string {
+	var result strings.Builder
+	i, n := 0, len(query)
+	for i < n {
+		ch := query[i]
+		switch ch {
+		case '\'':
+			i = copySQLStringLiteral(&result, query, i)
+		case '"':
+			i = copySQLQuotedIdentifier(&result, query, i)
+		default:
+			if isSQLIdentifierStart(ch) {
+				j := i + 1
+				for j < n && isSQLIdentifierChar(query[j]) {
+					j++
+				}
+
+				k, hasDot := j, false
+				for k < n && query[k] == '.' && k+1 < n && isSQLIdentifierChar(query[k+1]) {
+					hasDot = true
+					k++
+					for k < n && isSQLIdentifierChar(query[k]) {
+						k++
+					}
+				}
+
+				identifier := query[i:k]
+				if hasDot || shouldQuoteSQLFieldName(identifier, query, k) {
+					result.WriteByte('"')
+					result.WriteString(identifier)
+					result.WriteByte('"')
+					i = k
+				} else {
+					result.WriteString(query[i:j])
+					i = j
+				}
+				continue
+			}
+			result.WriteByte(ch)
+			i++
+		}
+	}
+	return result.String()
+}
+
+func copySQLStringLiteral(result *strings.Builder, query string, start int) int {
+	result.WriteByte(query[start])
+	i := start + 1
+	for i < len(query) {
+		c := query[i]
+		result.WriteByte(c)
+		i++
+		if c == '\'' {
+			if i < len(query) && query[i] == '\'' {
+				result.WriteByte(query[i])
+				i++
+				continue
+			}
+			break
+		}
+	}
+	return i
+}
+
+func copySQLQuotedIdentifier(result *strings.Builder, query string, start int) int {
+	result.WriteByte(query[start])
+	i := start + 1
+	for i < len(query) {
+		c := query[i]
+		result.WriteByte(c)
+		i++
+		if c == '"' {
+			if i < len(query) && query[i] == '"' {
+				result.WriteByte(query[i])
+				i++
+				continue
+			}
+			break
+		}
+	}
+	return i
+}
+
+func isSQLTableClauseAt(query string, idx int) bool {
+	return isSQLKeywordAt(query, idx, "from") || isSQLKeywordAt(query, idx, "join")
+}
+
+func sqlTableClauseLen(query string, idx int) int {
+	if isSQLKeywordAt(query, idx, "from") {
+		return len("from")
+	}
+	return len("join")
+}
+
+func isSQLKeywordAt(query string, idx int, keyword string) bool {
+	if idx+len(keyword) > len(query) || !strings.EqualFold(query[idx:idx+len(keyword)], keyword) {
+		return false
+	}
+	if idx > 0 && isIdentChar(rune(query[idx-1])) {
+		return false
+	}
+	next := idx + len(keyword)
+	return next >= len(query) || !isIdentChar(rune(query[next]))
+}
+
+func isSQLSpace(c byte) bool {
+	return c == ' ' || c == '\t' || c == '\n' || c == '\r'
+}
+
+func isSQLTableTokenEnd(c byte) bool {
+	return isSQLSpace(c) || c == ',' || c == ';' || c == '(' || c == ')'
+}
+
+func shouldQuoteSQLTableName(tableName string) bool {
+	if tableName == "" || strings.EqualFold(tableName, "dataset") {
+		return false
+	}
+	if !isSQLIdentifierStart(tableName[0]) {
+		return true
+	}
+	for i := 1; i < len(tableName); i++ {
+		if !isSQLIdentifierChar(tableName[i]) {
+			return true
+		}
+	}
+	return false
+}
+
+var sqlFieldKeywords = map[string]struct{}{
+	"all": {}, "and": {}, "as": {}, "asc": {}, "between": {}, "by": {}, "case": {}, "cast": {},
+	"desc": {}, "distinct": {}, "else": {}, "end": {}, "false": {}, "from": {}, "full": {},
+	"group": {}, "having": {}, "in": {}, "inner": {}, "is": {}, "join": {}, "left": {}, "like": {},
+	"limit": {}, "not": {}, "null": {}, "on": {}, "or": {}, "order": {}, "outer": {}, "right": {},
+	"select": {}, "then": {}, "true": {}, "when": {}, "where": {},
+}
+
+func shouldQuoteSQLFieldName(identifier, query string, end int) bool {
+	if _, ok := sqlFieldKeywords[strings.ToLower(identifier)]; ok {
+		return false
+	}
+	if nextNonSpaceByte(query, end) == '(' {
+		return false
+	}
+	return hasMixedCaseASCII(identifier)
+}
+
+func hasMixedCaseASCII(s string) bool {
+	hasUpper, hasLower := false, false
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c >= 'A' && c <= 'Z' {
+			hasUpper = true
+		}
+		if c >= 'a' && c <= 'z' {
+			hasLower = true
+		}
+	}
+	return hasUpper && hasLower
+}
+
+func nextNonSpaceByte(s string, start int) byte {
+	for start < len(s) {
+		if !isSQLSpace(s[start]) {
+			return s[start]
+		}
+		start++
+	}
+	return 0
+}
+
+func isSQLIdentifierStart(c byte) bool {
+	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || c == '_'
+}
+
+func isSQLIdentifierChar(c byte) bool {
+	return isSQLIdentifierStart(c) || (c >= '0' && c <= '9')
+}
+
 func NewFetchTask(profile config.Profile, query string, startTime string, endTime string) tea.Cmd {
 	return func() (msg tea.Msg) {
 		res := FetchData{
@@ -1687,6 +1998,8 @@ func IteratorPrev(iter *iterator.QueryIterator[QueryData, FetchResult]) tea.Cmd 
 func fetchData(client *http.Client, profile *config.Profile, query string, startTime string, endTime string) (data QueryData, res FetchResult, errMsg string) {
 	data = QueryData{}
 	res = fetchErr
+	query = quoteUnsafeSQLTableNames(query)
+	query = quoteUnsafeSQLFieldNames(query)
 	query = ensureDefaultSQLLimit(query)
 
 	body, err := json.Marshal(map[string]string{

--- a/pkg/model/query.go
+++ b/pkg/model/query.go
@@ -26,9 +26,9 @@ import (
 	"net/url"
 	"os"
 	"pb/pkg/config"
+	"pb/pkg/datasets"
 	"pb/pkg/iterator"
 	"pb/pkg/ui"
-	"sort"
 	"strings"
 	"time"
 
@@ -39,16 +39,19 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	table "github.com/evertras/bubble-table/table"
+	"github.com/muesli/reflow/truncate"
 	"golang.org/x/exp/slices"
 	"golang.org/x/term"
 )
 
 const (
-	// Trimmed display width — HH:MM:SS = 8 cells + slack.
-	dateTimeWidth = 10
+	dateTimeWidth = len("TIME [LOCAL]")
 	dateTimeKey   = "p_timestamp"
 	tagKey        = "p_tags"
 	metadataKey   = "p_metadata"
+
+	sqlControlTimeDisplayWidth = len("02 Jun 2026, 13:25 | UTC+05:30")
+	sqlControlsMinWidth        = sqlControlTimeDisplayWidth + 4 // border + row prefix
 )
 
 // Theme-derived styles. All palette atoms come from pkg/ui — to swap a
@@ -61,19 +64,6 @@ var (
 	StandardSecondary = ui.Adaptive(func(p ui.Palette) lipgloss.Color { return p.Mute })
 
 	chromeBorder = ui.Adaptive(func(p ui.Palette) lipgloss.Color { return p.Border })
-
-	borderedStyle = lipgloss.NewStyle().
-			Border(lipgloss.RoundedBorder(), true).
-			BorderForeground(chromeBorder).
-			Padding(0)
-
-	// Focused pane: single rounded border in brand accent. No double
-	// border (read as "alert" in TUI) — accent color carries the focus
-	// signal on its own.
-	borderedFocusStyle = lipgloss.NewStyle().
-				Border(lipgloss.RoundedBorder(), true).
-				BorderForeground(FocusPrimary).
-				Padding(0)
 
 	baseStyle = lipgloss.NewStyle().BorderForeground(chromeBorder)
 	// Header: bold + Accent fg, no background fill. Background tints
@@ -124,11 +114,11 @@ var (
 		InnerDivider: "│",
 	}
 
-	QueryNavigationMap = []string{"query", "dataset", "column", "time", "table"}
+	queryNavigationMap = []string{"query", "time", "dataset", "columns", "table"}
 )
 
 func sqlPageSize(totalH, bottomH int) int {
-	const topH = 14
+	const topH = 12
 	av := totalH - topH - bottomH
 	if av < 6 {
 		av = 6
@@ -179,6 +169,7 @@ type QueryModel struct {
 	table         table.Model
 	query         textarea.Model
 	timeRange     TimeInputModel
+	timeRangeEdit TimeInputModel
 	profile       config.Profile
 	help          help.Model
 	status        StatusBar
@@ -206,6 +197,7 @@ type QueryModel struct {
 	filteredColumns   []string
 	columnSelectedIdx int
 	columnsLoading    bool
+	columnsDrawerOpen bool
 
 	schema []string
 }
@@ -221,11 +213,77 @@ func (m *QueryModel) focusSelected() {
 		m.query.Focus()
 	case "table":
 		m.table = m.table.Focused(true)
+	case "columns":
+		m.columnFilter.Focus()
 	}
 }
 
-func (m *QueryModel) currentFocus() string {
-	return QueryNavigationMap[m.focused]
+func (m QueryModel) focusOrder() []string {
+	return queryNavigationMap
+}
+
+func (m QueryModel) currentFocus() string {
+	order := m.focusOrder()
+	if len(order) == 0 {
+		return "query"
+	}
+	if m.focused < 0 {
+		return order[0]
+	}
+	if m.focused >= len(order) {
+		return order[len(order)-1]
+	}
+	return order[m.focused]
+}
+
+func (m *QueryModel) focusPane(name string) {
+	for i, pane := range m.focusOrder() {
+		if pane == name {
+			m.focused = i
+			m.focusSelected()
+			return
+		}
+	}
+	m.focused = 0
+	m.focusSelected()
+}
+
+func (m *QueryModel) insertSelectedColumn() {
+	if len(m.filteredColumns) == 0 {
+		return
+	}
+	if m.columnSelectedIdx < 0 {
+		m.columnSelectedIdx = 0
+	}
+	if m.columnSelectedIdx >= len(m.filteredColumns) {
+		m.columnSelectedIdx = len(m.filteredColumns) - 1
+	}
+	m.selectedColumn = m.filteredColumns[m.columnSelectedIdx]
+	escaped := strings.ReplaceAll(m.selectedColumn, `"`, `""`)
+	m.query.InsertString(`"` + escaped + `" `)
+	m.focusPane("query")
+}
+
+func (m *QueryModel) toggleColumnsDrawer() tea.Cmd {
+	m.columnsDrawerOpen = !m.columnsDrawerOpen
+	if !m.columnsDrawerOpen {
+		m.focusPane("columns")
+		return nil
+	}
+
+	selected := m.dataset
+	if selected == "" {
+		if extracted := extractDataset(m.query.Value()); extracted != "—" && extracted != "" {
+			selected = extracted
+			m.dataset = selected
+		}
+	}
+	m.focusPane("columns")
+	if selected != "" && len(m.allColumns) == 0 && !m.columnsLoading {
+		m.columnsLoading = true
+		return fetchStreamSchema(m.profile, selected)
+	}
+	return nil
 }
 
 func NewQueryModel(profile config.Profile, queryStr string, startTime, endTime time.Time) QueryModel {
@@ -317,21 +375,22 @@ func NewQueryModel(profile config.Profile, queryStr string, startTime, endTime t
 
 	hasQuery := strings.TrimSpace(queryStr) != ""
 	model := QueryModel{
-		width:           w,
-		height:          h,
-		table:           table,
-		query:           query,
-		timeRange:       inputs,
-		overlay:         overlayNone,
-		profile:         profile,
-		help:            help,
-		spinner:         sp,
-		loading:         hasQuery,
-		hasQueried:      hasQuery,
-		queryIterator:   nil,
-		status:          status,
-		spotlightFilter: sf,
-		columnFilter:    cf,
+		width:             w,
+		height:            h,
+		table:             table,
+		query:             query,
+		timeRange:         inputs,
+		overlay:           overlayNone,
+		profile:           profile,
+		help:              help,
+		spinner:           sp,
+		loading:           hasQuery,
+		hasQueried:        hasQuery,
+		queryIterator:     nil,
+		status:            status,
+		spotlightFilter:   sf,
+		columnFilter:      cf,
+		columnsDrawerOpen: true,
 	}
 	return model
 }
@@ -392,8 +451,12 @@ func (m QueryModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					break
 				}
 			}
+			if m.columnsDrawerOpen && m.dataset != "" && len(m.allColumns) == 0 && !m.columnsLoading {
+				m.columnsLoading = true
+				cmds = append(cmds, fetchStreamSchema(m.profile, m.dataset))
+			}
 		}
-		return m, nil
+		return m, tea.Batch(cmds...)
 
 	case FetchData:
 		m.loading = false
@@ -409,8 +472,7 @@ func (m QueryModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			bh := lipgloss.Height(buildBottomBar(m, m.width))
 			m.table = m.table.WithPageSize(sqlPageSize(m.height, bh))
 			// Move focus to results table after a successful fetch.
-			m.focused = 4
-			m.focusSelected()
+			m.focusPane("table")
 		} else {
 			m.dataRows = []table.Row{}
 			m.table = m.table.WithRows([]table.Row{})
@@ -443,6 +505,7 @@ func (m QueryModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 						// dataset changed — reset column state
 						m.dataset = selected
 						m.selectedColumn = ""
+						m.columnFilter.SetValue("")
 						m.allColumns = []string{}
 						m.filteredColumns = []string{}
 					}
@@ -458,8 +521,7 @@ func (m QueryModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.overlay = overlayNone
 				m.spotlightFilter.SetValue("")
 				m.spotlightFilter.Blur()
-				m.focused = 0 // focus query editor after dataset select
-				m.focusSelected()
+				m.focusPane("query")
 				return m, tea.Batch(cmds...)
 
 			case tea.KeyUp:
@@ -535,6 +597,10 @@ func (m QueryModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		// special behavior on main page
 		if m.overlay == overlayNone {
+			if msg.String() == "ctrl+l" {
+				return m, m.toggleColumnsDrawer()
+			}
+
 			if msg.Type == tea.KeyCtrlD {
 				m.overlay = overlayDataset
 				m.spotlightFilter.Focus()
@@ -549,20 +615,24 @@ func (m QueryModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, fetchAllStreams(m.profile)
 			}
 
-			if msg.Type == tea.KeyEnter && m.currentFocus() == "column" {
-				m.overlay = overlayColumn
-				m.columnFilter.Focus()
+			if msg.Type == tea.KeyEnter && m.currentFocus() == "columns" {
+				if !m.columnsDrawerOpen {
+					return m, m.toggleColumnsDrawer()
+				}
+				m.insertSelectedColumn()
 				return m, nil
 			}
 
 			if msg.Type == tea.KeyEnter && m.currentFocus() == "time" {
+				m.timeRangeEdit = m.timeRange
+				m.timeRangeEdit.SyncPreset()
 				m.overlay = overlayInputs
 				return m, nil
 			}
 
 			if msg.Type == tea.KeyTab {
 				m.focused++
-				if m.focused > len(QueryNavigationMap)-1 {
+				if m.focused > len(m.focusOrder())-1 {
 					m.focused = 0
 				}
 				m.focusSelected()
@@ -572,22 +642,45 @@ func (m QueryModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if msg.Type == tea.KeyShiftTab {
 				m.focused--
 				if m.focused < 0 {
-					m.focused = len(QueryNavigationMap) - 1
+					m.focused = len(m.focusOrder()) - 1
 				}
 				m.focusSelected()
 				return m, nil
 			}
 
-			// up/down arrows navigate between dataset and column rows
-			if m.currentFocus() == "dataset" && msg.Type == tea.KeyDown {
-				m.focused = 2 // column
-				m.focusSelected()
-				return m, nil
-			}
-			if m.currentFocus() == "column" && msg.Type == tea.KeyUp {
-				m.focused = 1 // dataset
-				m.focusSelected()
-				return m, nil
+			if m.currentFocus() == "columns" && m.columnsDrawerOpen {
+				switch msg.Type {
+				case tea.KeyUp:
+					if m.columnSelectedIdx > 0 {
+						m.columnSelectedIdx--
+					}
+					return m, nil
+				case tea.KeyDown:
+					if m.columnSelectedIdx < len(m.filteredColumns)-1 {
+						m.columnSelectedIdx++
+					}
+					return m, nil
+				case tea.KeyRunes:
+					m.columnFilter.SetValue(m.columnFilter.Value() + string(msg.Runes))
+					m.filteredColumns = filterDatasets(m.allColumns, m.columnFilter.Value())
+					m.columnSelectedIdx = 0
+					return m, nil
+				case tea.KeyBackspace:
+					value := []rune(m.columnFilter.Value())
+					if len(value) > 0 {
+						m.columnFilter.SetValue(string(value[:len(value)-1]))
+						m.filteredColumns = filterDatasets(m.allColumns, m.columnFilter.Value())
+						m.columnSelectedIdx = 0
+					}
+					return m, nil
+				case tea.KeyEsc:
+					if m.columnFilter.Value() != "" {
+						m.columnFilter.SetValue("")
+						m.filteredColumns = m.allColumns
+						m.columnSelectedIdx = 0
+						return m, nil
+					}
+				}
 			}
 		}
 
@@ -601,6 +694,7 @@ func (m QueryModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, nil
 			}
 			if msg.Type == tea.KeyEnter {
+				m.timeRange = m.timeRangeEdit
 				m.overlay = overlayNone
 				m.focusSelected()
 				m.status.Error = ""
@@ -647,7 +741,7 @@ func (m QueryModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				}
 				cmds = append(cmds, cmd)
 			case overlayInputs:
-				m.timeRange, cmd = m.timeRange.Update(msg)
+				m.timeRangeEdit, cmd = m.timeRangeEdit.Update(msg)
 				cmds = append(cmds, cmd)
 			}
 		}
@@ -674,22 +768,21 @@ func (m QueryModel) View() string {
 	bottomView := buildBottomBar(m, m.width)
 	bottomHeight := lipgloss.Height(bottomView)
 
-	// ── 3. TOP row: editor (wide) + date (narrow). Plain rectangles,
-	// label-only chrome. Date pane stays compact per mock.
-	// Sidebar holds DATASET + FROM + TO = 8 content rows; topH must
-	// stay >= 11 (innerH = 9 fits 8 + spare) or the sidebar overflows
-	// and pushes the top border off-screen.
-	// Sidebar width matches PromQL so the two views read symmetric.
-	sidebarW := 30
+	// ── 3. TOP row: editor (wide) + controls (narrow). Plain rectangles,
+	// label-only chrome. Controls mirror Prism order: time first, dataset below.
+	// Sidebar is wide enough to show formatted time without truncating:
+	// "02 Jun 2026, 11:25 AM | UTC+05:30".
+	sidebarW := sqlControlsMinWidth
 	if m.width >= 140 {
-		sidebarW = 34
-	}
-	if m.width < 100 {
-		sidebarW = 26
+		sidebarW = sqlControlsMinWidth + 3
 	}
 
-	// topH = dateBox(7) + combined dataset+column box(7) = 14
-	const topH = 14
+	bodyH := m.height - crumbsHeight - bottomHeight
+	if bodyH < 12 {
+		bodyH = 12
+	}
+	const editorH = 12
+	fullHeightControls := m.columnsDrawerOpen && !m.columnsLoading && len(m.filteredColumns) > 0
 
 	// editorW reserves 1 col for the horizontal gap between editor
 	// and sidebar, so the two │ borders aren't flush against each other.
@@ -699,12 +792,12 @@ func (m QueryModel) View() string {
 		sidebarW = m.width - editorW - 1
 	}
 	m.query.SetWidth(editorW - 6)
-	editorBodyH := topH - 4 // border(2) + title(1) + spacer(1)
+	editorBodyH := editorH - 4 // border(2) + title(1) + spacer(1)
 	if editorBodyH < 1 {
 		editorBodyH = 1
 	}
 	m.query.SetHeight(editorBodyH)
-	editorPane := renderEditorPane(m.query.View(), editorW, topH, m.currentFocus() == "query")
+	editorPane := renderEditorPane(m.query.View(), editorW, editorH, m.currentFocus() == "query")
 
 	// Prefer the explicitly selected dataset; fall back to parsing the FROM clause.
 	dataset := m.dataset
@@ -717,38 +810,41 @@ func (m QueryModel) View() string {
 		dataset = "select-dataset"
 	}
 
-	// Two stacked sidebar boxes — DATE on top, combined DATASET+COLUMN below.
-	dateBox := renderSQLDateBox(
-		m.timeRange.start.Value(),
-		m.timeRange.end.Value(),
-		sidebarW, 7,
-		m.currentFocus() == "time",
-	)
-	colLabel := m.selectedColumn
-	if colLabel == "" {
-		colLabel = "<select column>"
+	controlsH := editorH
+	if fullHeightControls {
+		controlsH = bodyH
 	}
-	datasetColumnBox := renderSQLDatasetColumnBox(
-		dataset, colLabel, m.columnsLoading,
-		sidebarW, 7,
+	controlsPane := renderSQLControlsBox(
+		formatSQLControlTime(m.timeRange.start.Time(), m.timeRange.DisplayMode()),
+		formatSQLControlTime(m.timeRange.end.Time(), m.timeRange.DisplayMode()),
+		dataset,
+		m.filteredColumns,
+		m.columnSelectedIdx,
+		m.columnFilter.Value(),
+		m.columnsDrawerOpen,
+		m.columnsLoading,
+		sidebarW,
+		controlsH,
 		m.currentFocus(),
+		m.timeRange.DisplayMode(),
 	)
-	sidebarPane := lipgloss.JoinVertical(lipgloss.Left, datasetColumnBox, dateBox)
-
-	gap := lipgloss.NewStyle().Width(1).Height(topH).Render("")
-	topSection := lipgloss.JoinHorizontal(lipgloss.Top, editorPane, gap, sidebarPane)
 
 	// ── 4. Results / table area ───────────────────────────────────────
-	availH := m.height - crumbsHeight - topH - bottomHeight
+	availH := bodyH - editorH
 	if availH < 6 {
 		availH = 6
 	}
+	resultsH := availH
+	resultsW := m.width
+	if fullHeightControls {
+		resultsW = editorW
+	}
 	// Results pane border (2) + label row (1) = 3 rows of chrome.
-	resultsInnerH := availH - 3
+	resultsInnerH := resultsH - 3
 	if resultsInnerH < 3 {
 		resultsInnerH = 3
 	}
-	resultsInnerW := m.width - 4 // border(2) + h-padding(2)
+	resultsInnerW := resultsW - 4 // border(2) + h-padding(2)
 	if resultsInnerW < 10 {
 		resultsInnerW = 10
 	}
@@ -845,16 +941,24 @@ func (m QueryModel) View() string {
 		inner = strings.Join(lines, "\n")
 	}
 	// rowCount=0: row info lives in the footer line inside the pane body.
-	resultsPane := renderResultsPane(inner, m.width, availH, 0, m.currentFocus() == "table")
+	resultsPane := renderResultsPane(inner, resultsW, resultsH, 0, m.currentFocus() == "table")
+	resultsSection := resultsPane
 
 	// ── 5. Compose body or overlay ────────────────────────────────────
-	body := lipgloss.JoinVertical(lipgloss.Left, topSection, resultsPane)
+	topGap := lipgloss.NewStyle().Width(1).Height(editorH).Render("")
+	topSection := lipgloss.JoinHorizontal(lipgloss.Top, editorPane, topGap, controlsPane)
+	body := lipgloss.JoinVertical(lipgloss.Left, topSection, resultsSection)
+	if fullHeightControls {
+		leftSection := lipgloss.JoinVertical(lipgloss.Left, editorPane, resultsSection)
+		sideGap := lipgloss.NewStyle().Width(1).Height(bodyH).Render("")
+		body = lipgloss.JoinHorizontal(lipgloss.Top, leftSection, sideGap, controlsPane)
+	}
 	var mainView string
 	switch m.overlay {
 	case overlayNone:
 		mainView = body
 	case overlayInputs:
-		timeView := m.timeRange.View()
+		timeView := m.timeRangeEdit.View()
 		mainView = lipgloss.Place(m.width, m.height-crumbsHeight-bottomHeight,
 			lipgloss.Center, lipgloss.Center, timeView,
 			lipgloss.WithWhitespaceChars(" "),
@@ -880,10 +984,11 @@ func (m QueryModel) View() string {
 	return lipgloss.NewStyle().Width(m.width).Render(render)
 }
 
-// renderEditorPane draws a flat rectangle with a single label row
-// (Faint, top-left) and body below. NormalBorder per design — matches
-// the wireframe "plain rectangle with label inside" idiom.
 func renderEditorPane(body string, width, height int, focused bool) string {
+	return renderTitledPane("EDITOR", body, width, height, focused)
+}
+
+func renderTitledPane(title, body string, width, height int, focused bool) string {
 	p := ui.Active
 	borderColor := p.Border
 	titleFg := p.Faint
@@ -899,174 +1004,263 @@ func renderEditorPane(body string, width, height int, focused bool) string {
 	if innerH < 3 {
 		innerH = 3
 	}
-	title := lipgloss.NewStyle().Foreground(titleFg).Bold(focused).Render("EDITOR")
-	titleRow := lipgloss.NewStyle().Width(innerW).Padding(0, 1).Render(title)
-	spacer := lipgloss.NewStyle().Width(innerW).Render("")
-	bodyPane := lipgloss.NewStyle().
-		Width(innerW).
-		Height(innerH-2).
-		Padding(0, 1).
-		Render(body)
-	stack := lipgloss.JoinVertical(lipgloss.Left, titleRow, spacer, bodyPane)
-	return lipgloss.NewStyle().
-		Border(lipgloss.NormalBorder()).
-		BorderForeground(borderColor).
-		Render(stack)
+	borderStyle := lipgloss.NewStyle().Foreground(borderColor)
+	titleStyle := lipgloss.NewStyle().Foreground(titleFg).Bold(focused)
+	lines := []string{paneRule("┌", "┐", title, width, borderStyle, titleStyle)}
+	lines = append(lines, paneBodyLines(body, width, innerH, borderStyle)...)
+	lines = append(lines, borderStyle.Render("└"+strings.Repeat("─", innerW)+"┘"))
+	return lipgloss.JoinVertical(lipgloss.Left, lines...)
 }
 
-// renderSQLDatasetColumnBox draws a single sidebar card with both DATASET and
-// COLUMN rows. focusedOn is "dataset", "column", or "" (neither focused).
-// The active-rail highlight tracks which row is focused independently.
-func renderSQLDatasetColumnBox(dataset, column string, columnsLoading bool, width, height int, focusedOn string) string {
+func paneRule(left, right, title string, width int, borderStyle, titleStyle lipgloss.Style) string {
+	if width < 2 {
+		width = 2
+	}
+	if title == "" {
+		return borderStyle.Render(left + strings.Repeat("─", width-2) + right)
+	}
+	label := " " + title + " "
+	prefix := left + "──"
+	fill := width - lipgloss.Width(prefix) - lipgloss.Width(label) - lipgloss.Width(right)
+	if fill < 0 {
+		fill = 0
+		titleW := width - lipgloss.Width(prefix) - lipgloss.Width(right) - 2
+		if titleW < 1 {
+			titleW = 1
+		}
+		label = " " + ui.Truncate(title, titleW) + " "
+	}
+	return borderStyle.Render(prefix) + titleStyle.Render(label) + borderStyle.Render(strings.Repeat("─", fill)+right)
+}
+
+func paneBodyLines(body string, width, height int, borderStyle lipgloss.Style) []string {
+	innerW := width - 2
+	if innerW < 1 {
+		innerW = 1
+	}
+	textW := innerW - 2
+	if textW < 1 {
+		textW = 1
+	}
+	lines := strings.Split(body, "\n")
+	if len(lines) > height {
+		lines = lines[:height]
+	}
+	for len(lines) < height {
+		lines = append(lines, "")
+	}
+	out := make([]string, 0, height)
+	for _, line := range lines {
+		if lipgloss.Width(line) > textW {
+			line = truncate.String(line, uint(textW))
+		}
+		pad := textW - lipgloss.Width(line)
+		if pad < 0 {
+			pad = 0
+		}
+		out = append(out, borderStyle.Render("│")+" "+line+strings.Repeat(" ", pad)+" "+borderStyle.Render("│"))
+	}
+	return out
+}
+
+// renderSQLControlsBox draws the merged SQL sidebar control panel.
+// Order is intentionally TIME first, then DATASET and inline COLUMNS below.
+func renderSQLControlsBox(start, end, dataset string, columns []string, columnIdx int, columnFilter string, columnsOpen, columnsLoading bool, width, height int, focusedOn string, displayMode TimeDisplayMode) string {
 	p := ui.Active
 	innerW := width - 2
 	if innerW < 4 {
 		innerW = 4
-	}
-	innerH := height - 2
-	if innerH < 1 {
-		innerH = 1
 	}
 
 	rail := lipgloss.NewStyle().Background(p.Active).Render(" ")
 	dim := lipgloss.NewStyle().Foreground(p.Faint)
 	body := lipgloss.NewStyle().Foreground(p.Body)
-	ghost := lipgloss.NewStyle().Foreground(p.Ghost).Italic(true)
 	active := lipgloss.NewStyle().Foreground(p.Active).Bold(true)
-
-	// DATASET row
-	dsLabel, dsPrefix := dim, "  "
-	if focusedOn == "dataset" {
-		dsLabel = active
-		dsPrefix = rail + " "
-	}
-
-	// COLUMN row
-	colLabel, colPrefix := dim, "  "
-	if focusedOn == "column" {
-		colLabel = active
-		colPrefix = rail + " "
-	}
-	colDisplay := column
-	colValStyle := body
-	if columnsLoading {
-		colDisplay = "loading…"
-		colValStyle = ghost
-	} else if column == "<select column>" {
-		colValStyle = ghost
-	}
-
-	maxVal := innerW - lipgloss.Width(dsPrefix)
-	if maxVal < 4 {
-		maxVal = 4
-	}
-	lines := []string{
-		dsPrefix + dsLabel.Render("DATASET"),
-		dsPrefix + body.Render(ui.Truncate(dataset, maxVal)),
-		"",
-		colPrefix + colLabel.Render("COLUMN"),
-		colPrefix + colValStyle.Render(ui.Truncate(colDisplay, maxVal)),
-	}
-	content := lipgloss.NewStyle().
-		Width(innerW).
-		Height(innerH).
-		Render(lipgloss.JoinVertical(lipgloss.Left, lines...))
-
+	sectionFocused := focusedOn == "time" || focusedOn == "dataset" || focusedOn == "columns"
 	borderColor := p.Border
-	if focusedOn == "dataset" || focusedOn == "column" {
+	if sectionFocused {
 		borderColor = p.BorderHi
 	}
-	return lipgloss.NewStyle().
-		Border(lipgloss.NormalBorder()).
-		BorderForeground(borderColor).
-		Render(content)
-}
+	borderStyle := lipgloss.NewStyle().Foreground(borderColor)
+	timeTitleStyle := lipgloss.NewStyle().Foreground(p.Faint)
+	if focusedOn == "time" {
+		timeTitleStyle = lipgloss.NewStyle().Foreground(p.Accent).Bold(true)
+	}
+	datasetTitleStyle := lipgloss.NewStyle().Foreground(p.Faint)
+	if focusedOn == "dataset" {
+		datasetTitleStyle = lipgloss.NewStyle().Foreground(p.Accent).Bold(true)
+	}
+	columnsTitleStyle := lipgloss.NewStyle().Foreground(p.Faint)
+	if focusedOn == "columns" {
+		columnsTitleStyle = lipgloss.NewStyle().Foreground(p.Accent).Bold(true)
+	}
 
-// renderSQLDateBox draws the bottom SQL sidebar card: FROM + TO.
-// Focused state uses the Active (sky-blue) rail + bold label
-// convention shared with PromQL.
-func renderSQLDateBox(start, end string, width, height int, focused bool) string {
-	p := ui.Active
-	innerW := width - 2
-	if innerW < 4 {
-		innerW = 4
-	}
-	innerH := height - 2
-	if innerH < 1 {
-		innerH = 1
-	}
-	dim := lipgloss.NewStyle().Foreground(p.Faint)
-	val := lipgloss.NewStyle().Foreground(p.Body)
-	label := dim
-	prefix := "  "
-	if focused {
-		label = lipgloss.NewStyle().Foreground(p.Active).Bold(true)
-		prefix = lipgloss.NewStyle().Background(p.Active).Render(" ") + " "
-	}
-	valW := innerW - 2 // 2 for prefix
+	valW := innerW - 2
 	if valW < 4 {
 		valW = 4
 	}
-	lines := []string{
-		prefix + label.Render("FROM"),
-		prefix + val.Render(ui.Truncate(start, valW)),
-		"",
-		prefix + label.Render("TO"),
-		prefix + val.Render(ui.Truncate(end, valW)),
+	row := func(focus, label, value string, valueStyle lipgloss.Style, truncate bool) []string {
+		labelStyle := dim
+		prefix := "  "
+		if focusedOn == focus {
+			labelStyle = active
+			prefix = rail + " "
+		}
+		display := value
+		if truncate {
+			display = ui.Truncate(value, valW)
+		}
+		return []string{
+			prefix + labelStyle.Render(label),
+			prefix + valueStyle.Render(display),
+		}
 	}
-	body := lipgloss.NewStyle().
-		Width(innerW).
-		Height(innerH).
-		Render(lipgloss.JoinVertical(lipgloss.Left, lines...))
-	return lipgloss.NewStyle().
-		Border(lipgloss.NormalBorder()).
-		BorderForeground(p.Border).
-		Render(body)
+
+	truncateTime := valW < sqlControlTimeDisplayWidth
+	timeLines := []string{}
+	timeLines = append(timeLines, row("time", "FROM", start, body, truncateTime)...)
+	timeLines = append(timeLines, row("time", "TO", end, body, truncateTime)...)
+	timeLines = append(timeLines, "")
+
+	datasetPrefix := "  "
+	datasetStyle := body
+	if focusedOn == "dataset" {
+		datasetPrefix = rail + " "
+		datasetStyle = active
+	}
+	datasetLines := []string{
+		datasetPrefix + datasetStyle.Render(ui.Truncate(dataset, valW)),
+		"",
+	}
+
+	columnsTitle := fmt.Sprintf("COLUMNS (%d)", len(columns))
+	columnSectionH := height - 4 - len(timeLines) - len(datasetLines) // top + 2 dividers + bottom
+	if columnSectionH < 1 {
+		columnSectionH = 1
+	}
+	listAvailable := columnSectionH
+	footerH := 0
+	if columnsOpen && listAvailable > 1 {
+		footerH = 1
+		listAvailable--
+	}
+	if listAvailable < 1 {
+		listAvailable = 1
+	}
+	var columnLines []string
+	if !columnsOpen {
+		columnLines = append(columnLines, "  "+dim.Render("Show columns"))
+	} else if columnsLoading {
+		columnLines = append(columnLines, "  "+dim.Render("loading columns..."))
+	} else if len(columns) == 0 {
+		columnLines = append(columnLines, "  "+dim.Render("no columns"))
+	} else {
+		if columnIdx < 0 {
+			columnIdx = 0
+		}
+		if columnIdx >= len(columns) {
+			columnIdx = len(columns) - 1
+		}
+		listH := listAvailable
+		if listH < 1 {
+			listH = 1
+		}
+		startIdx := 0
+		if columnIdx >= listH {
+			startIdx = columnIdx - listH + 1
+		}
+		if startIdx+listH > len(columns) {
+			startIdx = len(columns) - listH
+			if startIdx < 0 {
+				startIdx = 0
+			}
+		}
+		for i := startIdx; i < startIdx+listH && i < len(columns); i++ {
+			col := ui.Truncate(columns[i], valW)
+			if focusedOn == "columns" && i == columnIdx {
+				columnLines = append(columnLines, highlightStyle.Width(valW).Render(col))
+			} else {
+				columnLines = append(columnLines, "  "+body.Render(col))
+			}
+		}
+	}
+	for len(columnLines) < listAvailable {
+		columnLines = append(columnLines, "")
+	}
+	if footerH == 1 {
+		columnLines = append(columnLines, renderColumnFilterFooter(columnFilter, columnIdx, len(columns), valW, focusedOn == "columns"))
+	}
+
+	lines := []string{
+		paneRule("┌", "┐", "TIME RANGE "+formatResultTimeLabel(displayMode), width, borderStyle, timeTitleStyle),
+	}
+	lines = append(lines, paneBodyLines(lipgloss.JoinVertical(lipgloss.Left, timeLines...), width, len(timeLines), borderStyle)...)
+	lines = append(lines, paneRule("├", "┤", "DATASET", width, borderStyle, datasetTitleStyle))
+	lines = append(lines, paneBodyLines(lipgloss.JoinVertical(lipgloss.Left, datasetLines...), width, len(datasetLines), borderStyle)...)
+	lines = append(lines, paneRule("├", "┤", columnsTitle, width, borderStyle, columnsTitleStyle))
+	lines = append(lines, paneBodyLines(lipgloss.JoinVertical(lipgloss.Left, columnLines...), width, columnSectionH, borderStyle)...)
+	lines = append(lines, borderStyle.Render("└"+strings.Repeat("─", innerW)+"┘"))
+	return lipgloss.JoinVertical(lipgloss.Left, lines...)
+}
+
+func renderColumnFilterFooter(columnFilter string, columnIdx, total, width int, focused bool) string {
+	p := ui.Active
+	dim := lipgloss.NewStyle().Foreground(p.Faint)
+	body := lipgloss.NewStyle().Foreground(p.Body)
+
+	count := "0/0"
+	if total > 0 {
+		current := columnIdx + 1
+		if current < 1 {
+			current = 1
+		}
+		if current > total {
+			current = total
+		}
+		count = fmt.Sprintf("%d/%d", current, total)
+	}
+
+	cursor := ""
+	cursorW := 0
+	if focused {
+		cursor = lipgloss.NewStyle().
+			Background(p.Cursor).
+			Foreground(p.InvertText).
+			Render(" ")
+		cursorW = 1
+	}
+
+	prefix := "filter: "
+	countW := lipgloss.Width(count)
+	filterW := width - lipgloss.Width(prefix) - countW - cursorW - 1
+	if filterW < 0 {
+		filterW = 0
+	}
+	left := dim.Render(prefix) + body.Render(ui.Truncate(columnFilter, filterW)) + cursor
+	right := dim.Render(count)
+	pad := width - lipgloss.Width(left) - lipgloss.Width(right)
+	if pad < 1 {
+		pad = 1
+	}
+	return left + strings.Repeat(" ", pad) + right
+}
+
+func formatSQLControlTime(t time.Time, mode TimeDisplayMode) string {
+	if mode == TimeDisplayUTC {
+		return t.UTC().Format("02 Jan 2006, 15:04 | UTC")
+	}
+	return t.Format("02 Jan 2006, 15:04 | UTC-07:00")
 }
 
 // renderResultsPane wraps the table (or empty-state / loading / error
 // body) in a flat rectangle with a single label row. Row count appears
 // dim-right of the label when there is data.
 func renderResultsPane(body string, width, height, rowCount int, focused bool) string {
-	p := ui.Active
-	borderColor := p.Border
-	titleFg := p.Faint
-	if focused {
-		borderColor = p.BorderHi
-		titleFg = p.Accent
-	}
-	innerW := width - 2
-	if innerW < 4 {
-		innerW = 4
-	}
-	innerH := height - 2
-	if innerH < 3 {
-		innerH = 3
-	}
-	left := lipgloss.NewStyle().Foreground(titleFg).Bold(focused).Render("RESULTS")
-	var right string
+	title := "RESULTS"
 	if rowCount > 0 {
-		right = lipgloss.NewStyle().
-			Foreground(p.Faint).
-			Render(fmt.Sprintf("%d rows", rowCount))
+		title = fmt.Sprintf("RESULTS (%d rows)", rowCount)
 	}
-	gap := innerW - lipgloss.Width(left) - lipgloss.Width(right) - 2
-	if gap < 1 {
-		gap = 1
-	}
-	titleRow := lipgloss.NewStyle().Width(innerW).Padding(0, 1).Render(
-		left + strings.Repeat(" ", gap) + right,
-	)
-	bodyPane := lipgloss.NewStyle().
-		Width(innerW).
-		Height(innerH-1).
-		Padding(0, 1).
-		Render(body)
-	stack := lipgloss.JoinVertical(lipgloss.Left, titleRow, bodyPane)
-	return lipgloss.NewStyle().
-		Border(lipgloss.NormalBorder()).
-		BorderForeground(borderColor).
-		Render(stack)
+	return renderTitledPane(title, body, width, height, focused)
 }
 
 // buildBottomBar — single combined help+status row. Left side carries
@@ -1150,10 +1344,15 @@ func queryKeysForFocus(m QueryModel) []ui.KeyHint {
 	}
 	switch m.overlay {
 	case overlayInputs:
+		upDownLabel := "Adjust"
+		if m.timeRangeEdit.currentFocus() == "list" {
+			upDownLabel = "Preset"
+		} else if m.timeRangeEdit.currentFocus() == "display" {
+			upDownLabel = "Display time"
+		}
 		return []ui.KeyHint{
-			{Key: "<↑/↓>", Label: "Preset"},
-			{Key: "<tab>", Label: "Field"},
-			{Key: "<ctrl-{>", Label: "End → now"},
+			{Key: "<↑/↓>", Label: upDownLabel},
+			{Key: "<tab>", Label: "Switch pane"},
 			{Key: "<enter>", Label: "Apply"},
 			{Key: "<esc>", Label: "Cancel"},
 		}
@@ -1164,10 +1363,16 @@ func queryKeysForFocus(m QueryModel) []ui.KeyHint {
 			{Key: "<enter>", Label: "Open selector"},
 			{Key: "<ctrl-d>", Label: "Open selector"},
 		}, common...)
-	case "column":
+	case "columns":
+		if m.columnsDrawerOpen {
+			return append([]ui.KeyHint{
+				{Key: "<↑/↓>", Label: "Column"},
+				{Key: "<enter>", Label: "Insert"},
+				{Key: "<type>", Label: "Filter"},
+			}, common...)
+		}
 		return append([]ui.KeyHint{
-			{Key: "<enter>", Label: "Open selector"},
-			{Key: "<ctrl-d>", Label: "Dataset"},
+			{Key: "<enter>", Label: "Show columns"},
 		}, common...)
 	case "time":
 		return append([]ui.KeyHint{
@@ -1182,22 +1387,58 @@ func queryKeysForFocus(m QueryModel) []ui.KeyHint {
 	return common
 }
 
-// trimTimestampToHMS extracts the HH:MM:SS portion of an RFC3339-ish
-// timestamp (or any string containing `T<time>`). Used to keep the
-// timestamp column narrow in the results table. Full value is still
-// stored — only the display string is trimmed.
-func trimTimestampToHMS(s string) string {
-	// Look for `T` separator (RFC3339) — take what follows, then crop
-	// at the first dot or zone marker.
-	t := strings.IndexByte(s, 'T')
+func formatResultTimeLabel(mode TimeDisplayMode) string {
+	if mode == TimeDisplayUTC {
+		return "[UTC]"
+	}
+	return "[LOCAL]"
+}
+
+func formatTimestampToDisplayHMS(value string, loc *time.Location, mode TimeDisplayMode) string {
+	if loc == nil {
+		loc = time.Local
+	}
+	if t, ok := parseTimestamp(value); ok {
+		if mode == TimeDisplayUTC {
+			return t.UTC().Format("15:04:05")
+		}
+		return t.In(loc).Format("15:04:05")
+	}
+	return trimTimestampToHMS(value)
+}
+
+func parseTimestamp(value string) (time.Time, bool) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return time.Time{}, false
+	}
+	for _, layout := range []string{time.RFC3339Nano, time.RFC3339} {
+		if t, err := time.Parse(layout, value); err == nil {
+			return t, true
+		}
+	}
+	for _, layout := range []string{
+		"2006-01-02T15:04:05.999999999",
+		"2006-01-02T15:04:05",
+		"2006-01-02 15:04:05.999999999",
+		"2006-01-02 15:04:05",
+	} {
+		if t, err := time.ParseInLocation(layout, value, time.UTC); err == nil {
+			return t, true
+		}
+	}
+	return time.Time{}, false
+}
+
+func trimTimestampToHMS(value string) string {
+	t := strings.IndexByte(value, 'T')
 	if t < 0 {
-		// Fallback: try a space (some formats use space, not T).
-		t = strings.IndexByte(s, ' ')
+		t = strings.IndexByte(value, ' ')
 	}
-	if t < 0 || t+1 >= len(s) {
-		return s
+	if t < 0 || t+1 >= len(value) {
+		return value
 	}
-	rest := s[t+1:]
+	rest := value[t+1:]
 	for i, c := range rest {
 		if c == '.' || c == 'Z' || c == '+' || c == '-' {
 			return rest[:i]
@@ -1207,6 +1448,75 @@ func trimTimestampToHMS(s string) string {
 		return rest[:8]
 	}
 	return rest
+}
+
+func ensureDefaultSQLLimit(query string) string {
+	trimmed := strings.TrimSpace(query)
+	if trimmed == "" || hasTopLevelSQLLimit(trimmed) {
+		return query
+	}
+	suffix := ""
+	if strings.HasSuffix(trimmed, ";") {
+		trimmed = strings.TrimSpace(strings.TrimSuffix(trimmed, ";"))
+		suffix = ";"
+	}
+	return trimmed + " LIMIT 500" + suffix
+}
+
+func hasTopLevelSQLLimit(query string) bool {
+	depth := 0
+	for i := 0; i < len(query); {
+		switch query[i] {
+		case '\'':
+			i++
+			for i < len(query) {
+				if query[i] == '\'' {
+					i++
+					if i < len(query) && query[i] == '\'' {
+						i++
+						continue
+					}
+					break
+				}
+				i++
+			}
+		case '"':
+			i++
+			for i < len(query) {
+				if query[i] == '"' {
+					i++
+					break
+				}
+				i++
+			}
+		case '(':
+			depth++
+			i++
+		case ')':
+			if depth > 0 {
+				depth--
+			}
+			i++
+		default:
+			if depth == 0 && isSQLLimitTokenAt(query, i) {
+				return true
+			}
+			i++
+		}
+	}
+	return false
+}
+
+func isSQLLimitTokenAt(query string, idx int) bool {
+	const token = "limit"
+	if idx+len(token) > len(query) || !strings.EqualFold(query[idx:idx+len(token)], token) {
+		return false
+	}
+	if idx > 0 && isIdentChar(rune(query[idx-1])) {
+		return false
+	}
+	next := idx + len(token)
+	return next >= len(query) || !isIdentChar(rune(query[next]))
 }
 
 // parseableASCIIArt is the block-letter wordmark shown in the empty
@@ -1377,6 +1687,7 @@ func IteratorPrev(iter *iterator.QueryIterator[QueryData, FetchResult]) tea.Cmd 
 func fetchData(client *http.Client, profile *config.Profile, query string, startTime string, endTime string) (data QueryData, res FetchResult, errMsg string) {
 	data = QueryData{}
 	res = fetchErr
+	query = ensureDefaultSQLLimit(query)
 
 	body, err := json.Marshal(map[string]string{
 		"query":     query,
@@ -1444,11 +1755,11 @@ func (m *QueryModel) UpdateTable(data FetchData) {
 
 	// Build column specs: timestamp pinned left, p_tags/p_metadata pinned right.
 	var specs []colSpec
+	resultLoc := m.timeRange.start.Time().Location()
+	resultTimeLabel := formatResultTimeLabel(m.timeRange.DisplayMode())
 
 	if slices.Contains(data.schema, dateTimeKey) {
-		// Display label "time" — full p_timestamp gets truncated to
-		// `P_TIMESTA…` at width 10. Short label fits cleanly.
-		specs = append(specs, colSpec{key: dateTimeKey, title: "time", width: dateTimeWidth, fixed: true})
+		specs = append(specs, colSpec{key: dateTimeKey, title: "time " + resultTimeLabel, width: dateTimeWidth, fixed: true})
 	}
 
 	for _, title := range data.schema {
@@ -1520,10 +1831,8 @@ func (m *QueryModel) UpdateTable(data FetchData) {
 
 	m.dataRows = make([]table.Row, len(data.data))
 	for i, rowJSON := range data.data {
-		// Mutate timestamp display in-place — HH:MM:SS only. Full value
-		// stays accessible when the row is expanded.
 		if ts, ok := rowJSON[dateTimeKey].(string); ok {
-			rowJSON[dateTimeKey] = trimTimestampToHMS(ts)
+			rowJSON[dateTimeKey] = formatTimestampToDisplayHMS(ts, resultLoc, m.timeRange.DisplayMode())
 		}
 		m.dataRows[i] = table.NewRow(rowJSON)
 	}
@@ -1580,64 +1889,15 @@ func countDigits(num int) int {
 	return numDigits
 }
 
-// fetchAllStreams fetches every log stream from the server and returns them
-// as a datasetListMsg. Used by the SQL dataset spotlight (all streams are
-// valid SQL targets, unlike PromQL which prefers "metrics" streams).
+// fetchAllStreams fetches Prism's dataset metadata and keeps log datasets,
+// matching the web UI's Logs section.
 func fetchAllStreams(profile config.Profile) tea.Cmd {
 	return func() tea.Msg {
-		reqURL, err := url.JoinPath(profile.URL, "api/v1/logstream")
+		items, err := datasets.FetchHomeDatasets(profile)
 		if err != nil {
 			return datasetListMsg{errMsg: err.Error()}
 		}
-		client := &http.Client{Timeout: 15 * time.Second}
-		req, err := http.NewRequest("GET", reqURL, nil)
-		if err != nil {
-			return datasetListMsg{errMsg: err.Error()}
-		}
-		if profile.Token != "" {
-			req.Header.Set("Authorization", "Bearer "+profile.Token)
-		} else {
-			req.SetBasicAuth(profile.Username, profile.Password)
-		}
-		resp, err := client.Do(req)
-		if err != nil {
-			return datasetListMsg{errMsg: err.Error()}
-		}
-		defer resp.Body.Close()
-		body, _ := io.ReadAll(resp.Body)
-		var items []struct {
-			Name       string `json:"name"`
-			StreamType string `json:"stream_type"`
-		}
-		if err := json.Unmarshal(body, &items); err != nil {
-			return datasetListMsg{errMsg: err.Error()}
-		}
-		// Prefer server-side stream_type (matches exactly what the UI shows).
-		// Fall back to name-based exclusion only for servers that don't
-		// return stream_type — never return everything unfiltered.
-		hasType := false
-		for _, item := range items {
-			if item.StreamType != "" {
-				hasType = true
-				break
-			}
-		}
-		datasets := make([]string, 0, len(items))
-		for _, item := range items {
-			if hasType {
-				if item.StreamType != "UserDefined" {
-					continue
-				}
-			} else {
-				low := strings.ToLower(item.Name)
-				if strings.Contains(low, "traces") || strings.Contains(low, "metrics") {
-					continue
-				}
-			}
-			datasets = append(datasets, item.Name)
-		}
-		sort.Strings(datasets)
-		return datasetListMsg{datasets: datasets}
+		return datasetListMsg{datasets: datasets.NamesByType(items, datasets.TypeLogs)}
 	}
 }
 

--- a/pkg/model/query_test.go
+++ b/pkg/model/query_test.go
@@ -1,0 +1,84 @@
+package model
+
+import (
+	"testing"
+	"time"
+)
+
+func TestFormatSQLControlTime(t *testing.T) {
+	ist := time.FixedZone("IST", 5*60*60+30*60)
+	value := time.Date(2026, time.June, 2, 11, 25, 24, 0, ist)
+
+	got := formatSQLControlTime(value, TimeDisplayLocal)
+	want := "02 Jun 2026, 11:25 | UTC+05:30"
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestFormatSQLControlTimeUTC(t *testing.T) {
+	ist := time.FixedZone("IST", 5*60*60+30*60)
+	value := time.Date(2026, time.June, 2, 11, 25, 24, 0, ist)
+
+	got := formatSQLControlTime(value, TimeDisplayUTC)
+	want := "02 Jun 2026, 05:55 | UTC"
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestFormatResultTimeLabelUsesBrackets(t *testing.T) {
+	if got := formatResultTimeLabel(TimeDisplayLocal); got != "[LOCAL]" {
+		t.Fatalf("local label = %q, want [LOCAL]", got)
+	}
+	if got := formatResultTimeLabel(TimeDisplayUTC); got != "[UTC]" {
+		t.Fatalf("utc label = %q, want [UTC]", got)
+	}
+}
+
+func TestFormatTimestampToDisplayHMSConvertsUTCToLocal(t *testing.T) {
+	ist := time.FixedZone("IST", 5*60*60+30*60)
+
+	got := formatTimestampToDisplayHMS("2026-06-02T09:13:59Z", ist, TimeDisplayLocal)
+	want := "14:43:59"
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestFormatTimestampToDisplayHMSTreatsNoZoneAsUTC(t *testing.T) {
+	ist := time.FixedZone("IST", 5*60*60+30*60)
+
+	got := formatTimestampToDisplayHMS("2026-06-02T09:13:59", ist, TimeDisplayLocal)
+	want := "14:43:59"
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestFormatTimestampToDisplayHMSUTC(t *testing.T) {
+	ist := time.FixedZone("IST", 5*60*60+30*60)
+
+	got := formatTimestampToDisplayHMS("2026-06-02T09:13:59Z", ist, TimeDisplayUTC)
+	want := "09:13:59"
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestEnsureDefaultSQLLimitAddsLimit(t *testing.T) {
+	query := `SELECT * FROM "astronomy-shop-logs"`
+	want := `SELECT * FROM "astronomy-shop-logs" LIMIT 500`
+
+	if got := ensureDefaultSQLLimit(query); got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestEnsureDefaultSQLLimitKeepsExistingLimit(t *testing.T) {
+	query := `SELECT * FROM "astronomy-shop-logs" LIMIT 10`
+
+	if got := ensureDefaultSQLLimit(query); got != query {
+		t.Fatalf("got %q, want %q", got, query)
+	}
+}

--- a/pkg/model/query_test.go
+++ b/pkg/model/query_test.go
@@ -82,3 +82,105 @@ func TestEnsureDefaultSQLLimitKeepsExistingLimit(t *testing.T) {
 		t.Fatalf("got %q, want %q", got, query)
 	}
 }
+
+func TestEnsureDefaultSQLLimitIgnoresLimitInComments(t *testing.T) {
+	tests := map[string]string{
+		`SELECT * FROM logs -- limit later`:         "SELECT * FROM logs -- limit later\nLIMIT 500",
+		`SELECT * FROM logs /* limit later */`:      `SELECT * FROM logs /* limit later */ LIMIT 500`,
+		`SELECT * FROM logs -- limit later` + "\n":  "SELECT * FROM logs -- limit later\nLIMIT 500",
+		`SELECT * FROM logs WHERE msg = 'limit 1'`:  `SELECT * FROM logs WHERE msg = 'limit 1' LIMIT 500`,
+		`SELECT * FROM logs WHERE "limit" = 'true'`: `SELECT * FROM logs WHERE "limit" = 'true' LIMIT 500`,
+	}
+
+	for query, want := range tests {
+		if got := ensureDefaultSQLLimit(query); got != want {
+			t.Fatalf("ensureDefaultSQLLimit(%q) = %q, want %q", query, got, want)
+		}
+	}
+}
+
+func TestEnsureDefaultSQLLimitKeepsRealLimitWithComments(t *testing.T) {
+	tests := []string{
+		`SELECT * FROM logs LIMIT 10 -- keep`,
+		`SELECT * FROM logs /* comment */ LIMIT 10`,
+	}
+
+	for _, query := range tests {
+		if got := ensureDefaultSQLLimit(query); got != query {
+			t.Fatalf("ensureDefaultSQLLimit(%q) = %q, want unchanged", query, got)
+		}
+	}
+}
+
+func TestQuoteUnsafeSQLTableNamesQuotesHyphenatedDataset(t *testing.T) {
+	query := `SELECT * FROM claudecode-logs LIMIT 100`
+	want := `SELECT * FROM "claudecode-logs" LIMIT 100`
+
+	if got := quoteUnsafeSQLTableNames(query); got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestQuoteUnsafeSQLTableNamesLeavesUnderscoreDatasetAlone(t *testing.T) {
+	query := `SELECT * FROM fly_logs LIMIT 100`
+
+	if got := quoteUnsafeSQLTableNames(query); got != query {
+		t.Fatalf("got %q, want %q", got, query)
+	}
+}
+
+func TestQuoteUnsafeSQLTableNamesLeavesPlaceholderAndQuotedDatasetAlone(t *testing.T) {
+	tests := []string{
+		`SELECT * FROM dataset LIMIT 100`,
+		`SELECT * FROM "claudecode-logs" LIMIT 100`,
+	}
+
+	for _, query := range tests {
+		if got := quoteUnsafeSQLTableNames(query); got != query {
+			t.Fatalf("got %q, want %q", got, query)
+		}
+	}
+}
+
+func TestQuoteUnsafeSQLTableNamesQuotesJoinAndOtherUnsafeNames(t *testing.T) {
+	tests := map[string]string{
+		`SELECT * FROM fly_logs JOIN claudecode-logs ON fly_logs.id = claudecode-logs.id`: `SELECT * FROM fly_logs JOIN "claudecode-logs" ON fly_logs.id = claudecode-logs.id`,
+		`SELECT * FROM metrics.v1 LIMIT 100`:                                              `SELECT * FROM "metrics.v1" LIMIT 100`,
+		`SELECT * FROM 123logs LIMIT 100`:                                                 `SELECT * FROM "123logs" LIMIT 100`,
+		`SELECT * FROM (SELECT * FROM claudecode-logs LIMIT 10) logs`:                     `SELECT * FROM (SELECT * FROM "claudecode-logs" LIMIT 10) logs`,
+	}
+
+	for query, want := range tests {
+		if got := quoteUnsafeSQLTableNames(query); got != want {
+			t.Fatalf("got %q, want %q", got, want)
+		}
+	}
+}
+
+func TestQuoteUnsafeSQLFieldNamesQuotesDottedAndMixedCaseFields(t *testing.T) {
+	query := `SELECT * FROM "astronomy-shop-logs" WHERE app.order.id > 100 AND StatusCode = 'FailedPrecondition' LIMIT 100`
+	want := `SELECT * FROM "astronomy-shop-logs" WHERE "app.order.id" > 100 AND "StatusCode" = 'FailedPrecondition' LIMIT 100`
+
+	if got := quoteUnsafeSQLFieldNames(query); got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestNormalizeInteractiveSQLQuotesTableAndFields(t *testing.T) {
+	query := "SELECT * FROM astronomy-shop-logs \nWHERE app.order.id > 100\nLIMIT 100;"
+	want := "SELECT * FROM \"astronomy-shop-logs\" \nWHERE \"app.order.id\" > 100\nLIMIT 100;"
+
+	got := quoteUnsafeSQLFieldNames(quoteUnsafeSQLTableNames(query))
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestQuoteUnsafeSQLFieldNamesLeavesKeywordsFunctionsStringsAndQuotedNamesAlone(t *testing.T) {
+	query := `SELECT COUNT(StatusCode) FROM "astronomy-shop-logs" WHERE "app.order.id" = 'app.order.id' AND service.name = 'cart'`
+	want := `SELECT COUNT("StatusCode") FROM "astronomy-shop-logs" WHERE "app.order.id" = 'app.order.id' AND "service.name" = 'cart'`
+
+	if got := quoteUnsafeSQLFieldNames(query); got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}

--- a/pkg/model/timeinput.go
+++ b/pkg/model/timeinput.go
@@ -17,53 +17,37 @@
 package model
 
 import (
-	"fmt"
 	"pb/pkg/model/datetime"
+	"pb/pkg/ui"
+	"strings"
 	"time"
 
-	"github.com/charmbracelet/bubbles/key"
 	"github.com/charmbracelet/bubbles/list"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/muesli/reflow/truncate"
 )
 
 var rangeNavigationMap = []string{
-	"list", "start", "end",
+	"list", "start", "end", "display",
 }
 
-type endTimeKeyBind struct {
-	ResetTime key.Binding
-	Ok        key.Binding
-}
+type TimeDisplayMode string
 
-func (k endTimeKeyBind) ShortHelp() []key.Binding {
-	return []key.Binding{k.ResetTime, k.Ok}
-}
-
-func (k endTimeKeyBind) FullHelp() [][]key.Binding {
-	return [][]key.Binding{
-		{k.ResetTime},
-		{k.Ok},
-	}
-}
-
-var endHelpBinds = endTimeKeyBind{
-	ResetTime: key.NewBinding(
-		key.WithKeys("ctrl+{"),
-		key.WithHelp("ctrl+{", "change end time to current time"),
-	),
-	Ok: key.NewBinding(
-		key.WithKeys("enter"),
-		key.WithHelp("enter", "save and go back"),
-	),
-}
+const (
+	// TimeDisplayLocal renders result timestamps in the selected local zone.
+	TimeDisplayLocal TimeDisplayMode = "local"
+	// TimeDisplayUTC renders result timestamps in UTC.
+	TimeDisplayUTC TimeDisplayMode = "utc"
+)
 
 type TimeInputModel struct {
-	start   datetime.Model
-	end     datetime.Model
-	list    list.Model
-	focus   int
-	instant bool
+	start       datetime.Model
+	end         datetime.Model
+	list        list.Model
+	focus       int
+	instant     bool
+	displayMode TimeDisplayMode
 }
 
 // SetInstant switches between range (start+end) and instant (end only) mode.
@@ -85,6 +69,22 @@ func (m *TimeInputModel) EndValueUtc() string {
 	return m.end.ValueUtc()
 }
 
+func (m *TimeInputModel) DisplayMode() TimeDisplayMode {
+	if m.displayMode == "" {
+		return TimeDisplayLocal
+	}
+	return m.displayMode
+}
+
+func (m *TimeInputModel) SetDisplayMode(mode TimeDisplayMode) {
+	switch mode {
+	case TimeDisplayUTC:
+		m.displayMode = TimeDisplayUTC
+	default:
+		m.displayMode = TimeDisplayLocal
+	}
+}
+
 func (m *TimeInputModel) SetStart(t time.Time) {
 	m.start.SetTime(t)
 }
@@ -93,10 +93,42 @@ func (m *TimeInputModel) SetEnd(t time.Time) {
 	m.end.SetTime(t)
 }
 
+func (m TimeInputModel) endTimeAllowed() bool {
+	if m.end.Time().After(time.Now()) {
+		return false
+	}
+	return m.instant || !m.end.Time().Before(m.start.Time())
+}
+
 // FocusEnd jumps directly to the end-time field — used by instant mode.
 func (m *TimeInputModel) FocusEnd() {
 	m.focus = 2 // index of "end" in rangeNavigationMap
 	m.focusSelected()
+}
+
+func (m *TimeInputModel) SyncPreset() {
+	target := m.start.Time().Sub(m.end.Time()).Round(time.Second)
+	if m.instant {
+		target = time.Until(m.end.Time()).Round(time.Second)
+	}
+	bestIdx := 0
+	bestDiff := durationAbs(target - timeDurations[0].(timeDurationItem).duration)
+	for i, item := range timeDurations {
+		duration := item.(timeDurationItem).duration
+		diff := durationAbs(target - duration)
+		if diff < bestDiff {
+			bestIdx = i
+			bestDiff = diff
+		}
+	}
+	m.list.Select(bestIdx)
+}
+
+func durationAbs(d time.Duration) time.Duration {
+	if d < 0 {
+		return -d
+	}
+	return d
 }
 
 func (m *TimeInputModel) focusSelected() {
@@ -106,8 +138,10 @@ func (m *TimeInputModel) focusSelected() {
 	switch m.currentFocus() {
 	case "start":
 		m.start.Focus()
+		m.start.FocusFirstSegment()
 	case "end":
 		m.end.Focus()
+		m.end.FocusFirstSegment()
 	}
 }
 
@@ -159,15 +193,12 @@ func NewTimeInputModel(startTime, endTime time.Time) TimeInputModel {
 	end.SetTime(endTime)
 
 	return TimeInputModel{
-		start: start,
-		end:   end,
-		list:  list,
-		focus: 0,
+		start:       start,
+		end:         end,
+		list:        list,
+		focus:       0,
+		displayMode: TimeDisplayLocal,
 	}
-}
-
-func (m TimeInputModel) FullHelp() [][]key.Binding {
-	return endHelpBinds.FullHelp()
 }
 
 func (m TimeInputModel) Init() tea.Cmd {
@@ -186,23 +217,44 @@ func (m TimeInputModel) Update(msg tea.Msg) (TimeInputModel, tea.Cmd) {
 		m.Navigate(key)
 		m.focusSelected()
 
-	case tea.KeyCtrlOpenBracket:
-		m.end.SetTime(time.Now())
 	default:
 		switch m.currentFocus() {
 		case "list":
+			if key.Type != tea.KeyUp && key.Type != tea.KeyDown {
+				return m, nil
+			}
+			prevDuration := m.list.SelectedItem().(timeDurationItem).duration
 			m.list, cmd = m.list.Update(key)
 			duration := m.list.SelectedItem().(timeDurationItem).duration
 			if m.instant {
-				// preset moves end backwards from now
-				m.SetEnd(time.Now().Add(duration))
+				// Presets move evaluation time relative to a stable anchor,
+				// so seconds don't jump while navigating the preset list.
+				anchor := m.end.Time().Add(-prevDuration)
+				m.SetEnd(anchor.Add(duration))
 			} else {
 				m.SetStart(m.end.Time().Add(duration))
 			}
 		case "start":
+			prev := m.start
 			m.start, cmd = m.start.Update(key)
+			if m.start.Time().After(m.end.Time()) {
+				m.start = prev
+			}
 		case "end":
+			prev := m.end
 			m.end, cmd = m.end.Update(key)
+			if !m.endTimeAllowed() {
+				m.end = prev
+			}
+		case "display":
+			switch key.Type {
+			case tea.KeyLeft, tea.KeyRight, tea.KeyUp, tea.KeyDown, tea.KeySpace:
+				if m.DisplayMode() == TimeDisplayLocal {
+					m.SetDisplayMode(TimeDisplayUTC)
+				} else {
+					m.SetDisplayMode(TimeDisplayLocal)
+				}
+			}
 		}
 	}
 
@@ -210,36 +262,224 @@ func (m TimeInputModel) Update(msg tea.Msg) (TimeInputModel, tea.Cmd) {
 }
 
 func (m TimeInputModel) View() string {
-	listStyle := &borderedStyle
-	startStyle := &borderedStyle
-	endStyle := &borderedStyle
+	const width = 72
+	const leftW = 27
+	const gapW = 2
+	rightW := width - 4 - leftW - gapW
+	p := ui.Active
+	borderStyle := lipgloss.NewStyle().Foreground(p.BorderHi)
+	titleStyle := lipgloss.NewStyle().Foreground(p.Accent).Bold(true)
+	labelStyle := lipgloss.NewStyle().Foreground(p.Faint).Bold(true)
 
-	switch m.currentFocus() {
-	case "list":
-		listStyle = &borderedFocusStyle
-	case "start":
-		startStyle = &borderedFocusStyle
-	case "end":
-		endStyle = &borderedFocusStyle
+	lines := []string{
+		paneRule("┌", "┐", "QUERY TIME", width, borderStyle, titleStyle),
 	}
 
-	list := lipgloss.NewStyle().PaddingLeft(1).Render(m.list.View())
-	left := listStyle.Render(lipgloss.PlaceHorizontal(27, lipgloss.Left, list))
-	center := baseStyle.Render("│\n│\n│\n│")
-	center = lipgloss.PlaceHorizontal(5, lipgloss.Center, center)
+	header := timePickerJoin(
+		labelStyle.Render("  PRESETS"),
+		labelStyle.Render("CUSTOM RANGE"),
+		leftW,
+		gapW,
+		rightW,
+	)
 
-	var right string
+	startBox := renderTimePickerInputBox("start", m.start, rightW, m.currentFocus() == "start", false)
+	endTitle := "end"
 	if m.instant {
-		// instant mode: only show end time, no start
-		label := lipgloss.NewStyle().Inherit(baseStyle).Bold(true).
-			Foreground(FocusSecondary).Render(" evaluation time ")
-		right = fmt.Sprintf("%s\n%s", label, endStyle.Render(m.end.View()))
-	} else {
-		right = fmt.Sprintf("%s\n\n%s",
-			startStyle.Render(m.start.View()),
-			endStyle.Render(m.end.View()),
-		)
+		endTitle = "evaluation time"
+	}
+	endBox := renderTimePickerInputBox(endTitle, m.end, rightW, m.currentFocus() == "end", true)
+	if m.instant {
+		startBox = []string{"", "", ""}
 	}
 
-	return lipgloss.JoinHorizontal(lipgloss.Center, left, center, right)
+	displayRows := renderTimeDisplayMode(m.DisplayMode(), rightW, m.currentFocus() == "display")
+
+	rows := []string{header}
+	for i := 0; i < 9; i++ {
+		left := ""
+		if i < len(timeDurations) {
+			left = renderTimePickerPreset(i, m.list.Index(), m.currentFocus() == "list")
+		}
+		right := ""
+		switch i {
+		case 0, 1, 2:
+			right = startBox[i]
+		case 3, 4, 5:
+			right = endBox[i-3]
+		case 6, 7:
+			right = displayRows[i-6]
+		}
+		rows = append(rows, timePickerJoin(left, right, leftW, gapW, rightW))
+	}
+
+	lines = append(lines, paneBodyLines(lipgloss.JoinVertical(lipgloss.Left, rows...), width, len(rows), borderStyle)...)
+	lines = append(lines, borderStyle.Render("└"+strings.Repeat("─", width-2)+"┘"))
+	return lipgloss.JoinVertical(lipgloss.Left, lines...)
+}
+
+func renderTimePickerPreset(index, selected int, focused bool) string {
+	item := timeDurations[index].(timeDurationItem)
+	p := ui.Active
+	name := lipgloss.NewStyle().Foreground(p.Body).Render(item.repr)
+	if index != selected {
+		return "  " + name
+	}
+	if focused {
+		rail := lipgloss.NewStyle().Background(p.Active).Render(" ")
+		name = lipgloss.NewStyle().Foreground(p.Active).Bold(true).Render(item.repr)
+		return rail + " " + name
+	}
+	name = lipgloss.NewStyle().Foreground(p.Accent).Bold(true).Render(item.repr)
+	return "  " + name
+}
+
+func renderTimeDisplayMode(mode TimeDisplayMode, width int, focused bool) []string {
+	p := ui.Active
+	labelStyle := lipgloss.NewStyle().Foreground(p.Faint).Bold(true)
+	if focused {
+		labelStyle = labelStyle.Foreground(p.Active)
+	}
+	active := lipgloss.NewStyle().Foreground(p.InvertText).Background(p.Active).Bold(true)
+	inactive := lipgloss.NewStyle().Foreground(p.Body)
+
+	localLabel := " Local " + time.Now().Format("UTC-07:00") + " "
+	local := inactive.Render(localLabel)
+	utc := inactive.Render(" UTC ")
+	if mode == TimeDisplayUTC {
+		utc = active.Render(" UTC ")
+	} else {
+		local = active.Render(localLabel)
+	}
+
+	line := local + "  " + utc
+	if lipgloss.Width(line) > width {
+		line = truncate.String(line, uint(width))
+	}
+	return []string{
+		labelStyle.Render("DISPLAY RESULTS AS"),
+		line,
+	}
+}
+
+func renderTimePickerInputBox(title string, input datetime.Model, width int, focused, showNow bool) []string {
+	p := ui.Active
+	borderColor := p.Border
+	titleColor := p.Faint
+	if focused {
+		borderColor = p.Active
+		titleColor = p.Active
+	}
+	borderStyle := lipgloss.NewStyle().Foreground(borderColor)
+	titleStyle := lipgloss.NewStyle().Foreground(titleColor).Bold(focused)
+	top := paneRule("┌", "┐", title, width, borderStyle, titleStyle)
+	innerW := width - 2
+	valueW := innerW - 2
+	if valueW < 1 {
+		valueW = 1
+	}
+	value := renderSegmentedTime(input.LocalValue(), input.CursorPosition(), focused)
+	if showNow {
+		now := lipgloss.NewStyle().Foreground(p.Active).Bold(true).Render("[NOW]")
+		valuePlainW := valueW - lipgloss.Width(now) - 1
+		if valuePlainW < 1 {
+			valuePlainW = 1
+		}
+		value = renderSegmentedTime(input.LocalValue(), input.CursorPosition(), focused)
+		if lipgloss.Width(value) > valuePlainW {
+			value = truncate.String(value, uint(valuePlainW))
+		}
+		pad := valueW - lipgloss.Width(value) - lipgloss.Width(now)
+		if pad < 1 {
+			pad = 1
+		}
+		value = value + strings.Repeat(" ", pad) + now
+	}
+	if lipgloss.Width(value) > valueW {
+		value = truncate.String(value, uint(valueW))
+	}
+	pad := valueW - lipgloss.Width(value)
+	if pad < 0 {
+		pad = 0
+	}
+	mid := borderStyle.Render("│") + " " + value + strings.Repeat(" ", pad) + " " + borderStyle.Render("│")
+	bottom := borderStyle.Render("└" + strings.Repeat("─", width-2) + "┘")
+	return []string{top, mid, bottom}
+}
+
+func renderSegmentedTime(value string, cursor int, focused bool) string {
+	p := ui.Active
+	normal := lipgloss.NewStyle().Foreground(p.Body)
+	if !focused || value == "" {
+		return normal.Render(value)
+	}
+	runes := []rune(value)
+	if cursor < 0 {
+		cursor = 0
+	}
+	if cursor >= len(runes) {
+		cursor = len(runes) - 1
+	}
+	start, end := timeSegmentBounds(runes, cursor)
+	active := lipgloss.NewStyle().Background(p.Active).Foreground(p.InvertText).Bold(true)
+	return normal.Render(string(runes[:start])) + active.Render(string(runes[start:end])) + normal.Render(string(runes[end:]))
+}
+
+func timeSegmentBounds(runes []rune, cursor int) (int, int) {
+	if len(runes) == 0 {
+		return 0, 0
+	}
+	if cursor >= len(runes) {
+		cursor = len(runes) - 1
+	}
+	if !isTimeSegmentChar(runes[cursor]) {
+		if cursor+1 < len(runes) && isTimeSegmentChar(runes[cursor+1]) {
+			cursor++
+		} else if cursor > 0 && isTimeSegmentChar(runes[cursor-1]) {
+			cursor--
+		}
+	}
+	start := cursor
+	for start > 0 && sameTimeSegmentKind(runes[start-1], runes[cursor]) {
+		start--
+	}
+	end := cursor + 1
+	for end < len(runes) && sameTimeSegmentKind(runes[end], runes[cursor]) {
+		end++
+	}
+	return start, end
+}
+
+func isTimeSegmentChar(r rune) bool {
+	return isTimeDigit(r) || isTimeLetter(r)
+}
+
+func sameTimeSegmentKind(a, b rune) bool {
+	return (isTimeDigit(a) && isTimeDigit(b)) || (isTimeLetter(a) && isTimeLetter(b))
+}
+
+func isTimeDigit(r rune) bool {
+	return r >= '0' && r <= '9'
+}
+
+func isTimeLetter(r rune) bool {
+	return (r >= 'A' && r <= 'Z') || (r >= 'a' && r <= 'z')
+}
+
+func timePickerJoin(left, right string, leftW, gapW, rightW int) string {
+	if lipgloss.Width(left) > leftW {
+		left = truncate.String(left, uint(leftW))
+	}
+	if lipgloss.Width(right) > rightW {
+		right = truncate.String(right, uint(rightW))
+	}
+	leftPad := leftW - lipgloss.Width(left)
+	if leftPad < 0 {
+		leftPad = 0
+	}
+	rightPad := rightW - lipgloss.Width(right)
+	if rightPad < 0 {
+		rightPad = 0
+	}
+	return left + strings.Repeat(" ", leftPad+gapW) + right + strings.Repeat(" ", rightPad)
 }

--- a/pkg/model/timeinput.go
+++ b/pkg/model/timeinput.go
@@ -32,6 +32,8 @@ var rangeNavigationMap = []string{
 	"list", "start", "end", "display",
 }
 
+const nowBadgeTolerance = 2 * time.Second
+
 type TimeDisplayMode string
 
 const (
@@ -129,6 +131,10 @@ func durationAbs(d time.Duration) time.Duration {
 		return -d
 	}
 	return d
+}
+
+func shouldShowNowBadge(t time.Time) bool {
+	return durationAbs(time.Since(t)) <= nowBadgeTolerance
 }
 
 func (m *TimeInputModel) focusSelected() {
@@ -288,12 +294,12 @@ func (m TimeInputModel) View() string {
 	if m.instant {
 		endTitle = "evaluation time"
 	}
-	endBox := renderTimePickerInputBox(endTitle, m.end, rightW, m.currentFocus() == "end", true)
+	endBox := renderTimePickerInputBox(endTitle, m.end, rightW, m.currentFocus() == "end", shouldShowNowBadge(m.end.Time()))
 	if m.instant {
 		startBox = []string{"", "", ""}
 	}
 
-	displayRows := renderTimeDisplayMode(m.DisplayMode(), rightW, m.currentFocus() == "display")
+	displayRows := renderTimeDisplayMode(m.DisplayMode(), rightW, m.currentFocus() == "display", m.end.Time())
 
 	rows := []string{header}
 	for i := 0; i < 9; i++ {
@@ -334,7 +340,7 @@ func renderTimePickerPreset(index, selected int, focused bool) string {
 	return "  " + name
 }
 
-func renderTimeDisplayMode(mode TimeDisplayMode, width int, focused bool) []string {
+func renderTimeDisplayMode(mode TimeDisplayMode, width int, focused bool, referenceTime time.Time) []string {
 	p := ui.Active
 	labelStyle := lipgloss.NewStyle().Foreground(p.Faint).Bold(true)
 	if focused {
@@ -343,7 +349,7 @@ func renderTimeDisplayMode(mode TimeDisplayMode, width int, focused bool) []stri
 	active := lipgloss.NewStyle().Foreground(p.InvertText).Background(p.Active).Bold(true)
 	inactive := lipgloss.NewStyle().Foreground(p.Body)
 
-	localLabel := " Local " + time.Now().Format("UTC-07:00") + " "
+	localLabel := " Local " + referenceTime.Format("UTC-07:00") + " "
 	local := inactive.Render(localLabel)
 	utc := inactive.Render(" UTC ")
 	if mode == TimeDisplayUTC {

--- a/pkg/model/timeinput_test.go
+++ b/pkg/model/timeinput_test.go
@@ -1,0 +1,194 @@
+package model
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func TestTimeInputTabFromPresetFocusesCustomRange(t *testing.T) {
+	now := time.Now()
+	m := NewTimeInputModel(now.Add(-time.Hour), now)
+
+	var cmd tea.Cmd
+	m, cmd = m.Update(tea.KeyMsg{Type: tea.KeyTab})
+	if cmd != nil {
+		t.Fatalf("tab from preset returned unexpected command")
+	}
+	if got := m.currentFocus(); got != "start" {
+		t.Fatalf("focus = %q, want start", got)
+	}
+	if got := m.start.CursorPosition(); got != 0 {
+		t.Fatalf("start cursor = %d, want first segment", got)
+	}
+}
+
+func TestTimeInputTabReachesDisplayTime(t *testing.T) {
+	now := time.Now()
+	m := NewTimeInputModel(now.Add(-time.Hour), now)
+
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyTab})
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyTab})
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyTab})
+
+	if got := m.currentFocus(); got != "display" {
+		t.Fatalf("focus = %q, want display", got)
+	}
+}
+
+func TestTimeInputTabFromPresetFocusesInstantEvaluationTime(t *testing.T) {
+	now := time.Now()
+	m := NewTimeInputModel(now.Add(-time.Hour), now)
+	m.SetInstant(true)
+
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyTab})
+	if got := m.currentFocus(); got != "end" {
+		t.Fatalf("focus = %q, want end", got)
+	}
+	if got := m.end.CursorPosition(); got != 0 {
+		t.Fatalf("evaluation cursor = %d, want first segment", got)
+	}
+}
+
+func TestTimeInputInstantTabReachesDisplayTime(t *testing.T) {
+	now := time.Now()
+	m := NewTimeInputModel(now.Add(-time.Hour), now)
+	m.SetInstant(true)
+
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyTab})
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyTab})
+
+	if got := m.currentFocus(); got != "display" {
+		t.Fatalf("focus = %q, want display", got)
+	}
+}
+
+func TestTimeInputRangeEndCannotMoveBeforeStart(t *testing.T) {
+	now := time.Now()
+	m := NewTimeInputModel(now, now)
+	m.FocusEnd()
+
+	before := m.end.Time()
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyDown})
+
+	if !m.end.Time().Equal(before) {
+		t.Fatalf("end changed to %s, want unchanged %s", m.end.Time(), before)
+	}
+}
+
+func TestTimeInputRangeEndCannotMoveIntoFuture(t *testing.T) {
+	now := time.Now()
+	m := NewTimeInputModel(now.Add(-time.Hour), now)
+	m.FocusEnd()
+
+	before := m.end.Time()
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyUp})
+
+	if !m.end.Time().Equal(before) {
+		t.Fatalf("end changed to %s, want unchanged %s", m.end.Time(), before)
+	}
+	if m.end.Time().After(time.Now()) {
+		t.Fatalf("end moved into future: %s", m.end.Time())
+	}
+}
+
+func TestTimeInputInstantEndCannotMoveIntoFuture(t *testing.T) {
+	now := time.Now()
+	m := NewTimeInputModel(now.Add(-time.Hour), now)
+	m.SetInstant(true)
+	m.FocusEnd()
+
+	before := m.end.Time()
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyUp})
+
+	if !m.end.Time().Equal(before) {
+		t.Fatalf("instant end changed to %s, want unchanged %s", m.end.Time(), before)
+	}
+	if m.end.Time().After(time.Now()) {
+		t.Fatalf("instant end moved into future: %s", m.end.Time())
+	}
+}
+
+func TestTimeInputInstantPresetKeepsSecondsStable(t *testing.T) {
+	now := time.Date(2026, 6, 3, 12, 34, 42, 0, time.Local)
+	m := NewTimeInputModel(now.Add(-time.Hour), now.Add(-time.Hour))
+	m.SetInstant(true)
+
+	before := m.end.Time()
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyDown})
+
+	if got := m.end.Time().Second(); got != before.Second() {
+		t.Fatalf("seconds = %d, want %d", got, before.Second())
+	}
+	if diff := before.Sub(m.end.Time()); diff != 4*time.Hour {
+		t.Fatalf("preset jump = %s, want 4h from 1 Hour to 5 Hours", diff)
+	}
+}
+
+func TestTimeInputPresetIgnoresLeftRight(t *testing.T) {
+	now := time.Date(2026, 6, 3, 12, 34, 42, 0, time.Local)
+	m := NewTimeInputModel(now.Add(-time.Hour), now.Add(-time.Hour))
+	m.SetInstant(true)
+
+	before := m.end.Time()
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyRight})
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyLeft})
+
+	if !m.end.Time().Equal(before) {
+		t.Fatalf("evaluation time changed to %s, want unchanged %s", m.end.Time(), before)
+	}
+}
+
+func TestTimeInputInstantEvaluationLeftRightMovesSegment(t *testing.T) {
+	now := time.Now()
+	m := NewTimeInputModel(now.Add(-time.Hour), now.Add(-time.Hour))
+	m.SetInstant(true)
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyTab})
+
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyRight})
+	if got := m.end.CursorPosition(); got != 5 {
+		t.Fatalf("cursor after right = %d, want month segment", got)
+	}
+
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyLeft})
+	if got := m.end.CursorPosition(); got != 0 {
+		t.Fatalf("cursor after left = %d, want year segment", got)
+	}
+}
+
+func TestTimeInputDisplayModeToggles(t *testing.T) {
+	now := time.Now()
+	m := NewTimeInputModel(now.Add(-time.Hour), now)
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyTab})
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyTab})
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyTab})
+
+	if got := m.DisplayMode(); got != TimeDisplayLocal {
+		t.Fatalf("display mode = %q, want local", got)
+	}
+
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyRight})
+	if got := m.DisplayMode(); got != TimeDisplayUTC {
+		t.Fatalf("display mode = %q, want utc", got)
+	}
+
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyLeft})
+	if got := m.DisplayMode(); got != TimeDisplayLocal {
+		t.Fatalf("display mode = %q, want local", got)
+	}
+}
+
+func TestTimeInputViewLabelsResultDisplayMode(t *testing.T) {
+	now := time.Now()
+	m := NewTimeInputModel(now.Add(-time.Hour), now)
+
+	view := m.View()
+	if !strings.Contains(view, "QUERY TIME") {
+		t.Fatalf("view should label query time picker, got:\n%s", view)
+	}
+	if !strings.Contains(view, "DISPLAY RESULTS AS") {
+		t.Fatalf("view should label result display mode, got:\n%s", view)
+	}
+}

--- a/pkg/model/timeinput_test.go
+++ b/pkg/model/timeinput_test.go
@@ -127,6 +127,18 @@ func TestTimeInputInstantPresetKeepsSecondsStable(t *testing.T) {
 	}
 }
 
+func TestTimeInputNowBadgeOnlyForCurrentTime(t *testing.T) {
+	if !shouldShowNowBadge(time.Now()) {
+		t.Fatalf("current time should show NOW badge")
+	}
+	if shouldShowNowBadge(time.Now().Add(-time.Hour)) {
+		t.Fatalf("historical time should not show NOW badge")
+	}
+	if shouldShowNowBadge(time.Now().Add(time.Hour)) {
+		t.Fatalf("future time should not show NOW badge")
+	}
+}
+
 func TestTimeInputPresetIgnoresLeftRight(t *testing.T) {
 	now := time.Date(2026, 6, 3, 12, 34, 42, 0, time.Local)
 	m := NewTimeInputModel(now.Add(-time.Hour), now.Add(-time.Hour))
@@ -190,5 +202,16 @@ func TestTimeInputViewLabelsResultDisplayMode(t *testing.T) {
 	}
 	if !strings.Contains(view, "DISPLAY RESULTS AS") {
 		t.Fatalf("view should label result display mode, got:\n%s", view)
+	}
+}
+
+func TestTimeInputDisplayModeUsesSelectedEndOffset(t *testing.T) {
+	ref := time.Date(2026, 1, 2, 3, 4, 5, 0, time.FixedZone("Example", -5*60*60))
+
+	rows := renderTimeDisplayMode(TimeDisplayLocal, 72, false, ref)
+	view := strings.Join(rows, "\n")
+
+	if !strings.Contains(view, "UTC-05:00") {
+		t.Fatalf("display mode should use selected end offset, got:\n%s", view)
 	}
 }

--- a/pkg/ui/views/picker.go
+++ b/pkg/ui/views/picker.go
@@ -16,15 +16,12 @@
 package views
 
 import (
-	"encoding/json"
 	"fmt"
-	"io"
-	"net/http"
 	"pb/pkg/config"
+	"pb/pkg/datasets"
 	"pb/pkg/ui"
 	"sort"
 	"strings"
-	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
@@ -343,76 +340,24 @@ func kindColor(kind string) lipgloss.Color {
 	return p.Accent // logs (default)
 }
 
-// fetchDatasets calls /api/v1/logstream and infers kind from name.
-// (Mirrors fetchMetricDatasets in pkg/model/promql.go but kept local so
-// the greenfield UI has no legacy dependency.)
+// fetchDatasets calls Prism's home API and uses datasetType, matching the web UI.
 func fetchDatasets(profile config.Profile) tea.Cmd {
 	return func() tea.Msg {
-		client := &http.Client{Timeout: 15 * time.Second}
-		req, err := http.NewRequest("GET", strings.TrimRight(profile.URL, "/")+"/api/v1/logstream", nil)
+		items, err := datasets.FetchHomeDatasets(profile)
 		if err != nil {
 			return datasetListMsg{err: err.Error()}
 		}
-		if profile.Token != "" {
-			req.Header.Set("Authorization", "Bearer "+profile.Token)
-		} else {
-			req.SetBasicAuth(profile.Username, profile.Password)
-		}
-		resp, err := client.Do(req)
-		if err != nil {
-			return datasetListMsg{err: err.Error()}
-		}
-		defer resp.Body.Close()
-		const limit = 10 * 1024 * 1024
-		body, err := io.ReadAll(io.LimitReader(resp.Body, limit+1))
-		if err != nil {
-			return datasetListMsg{err: "failed to read response: " + err.Error()}
-		}
-		if len(body) > limit {
-			return datasetListMsg{err: "response too large (>10 MB)"}
-		}
-		if resp.StatusCode >= 400 {
-			return datasetListMsg{err: fmt.Sprintf("HTTP %d: %s", resp.StatusCode, truncate(string(body), 200))}
-		}
-		var raw []struct {
-			Name string `json:"name"`
-		}
-		if err := json.Unmarshal(body, &raw); err != nil {
-			return datasetListMsg{err: err.Error()}
-		}
-		out := make([]dsItem, 0, len(raw))
-		for _, r := range raw {
+		out := make([]dsItem, 0, len(items))
+		for _, item := range items {
 			out = append(out, dsItem{
-				Name:   r.Name,
-				Kind:   inferKind(r.Name),
+				Name:   item.Title,
+				Kind:   item.DatasetType,
 				Fields: 0, // populated lazily on selection
 			})
 		}
 		sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
 		return datasetListMsg{items: out}
 	}
-}
-
-func inferKind(name string) string {
-	n := strings.ToLower(name)
-	switch {
-	case strings.Contains(n, "metric"):
-		return "metrics"
-	case strings.Contains(n, "trace"):
-		return "traces"
-	case strings.Contains(n, "event"):
-		return "events"
-	default:
-		return "logs"
-	}
-}
-
-func truncate(s string, n int) string {
-	runes := []rune(s)
-	if len(runes) <= n {
-		return s
-	}
-	return string(runes[:n]) + "…"
 }
 
 func max0(n int) int {


### PR DESCRIPTION
## Summary

This PR improves the CLI experience across dataset management, SQL/PromQL workflows, auth/profile handling, and help.

### Dataset management

- Adds telemetry-aware dataset creation:
  - `pb dataset add <name>` opens a themed picker for `logs`, `metrics`, or `traces`
  - `pb dataset add <name> --type logs|metrics|traces` supports scripts
- Sends the correct telemetry headers when creating metrics/traces datasets.
- Adds a guarded remove flow:
  - `pb dataset remove <name> --type logs|metrics|traces`
  - refuses deletion if the existing dataset type does not match
- Uses Prism home dataset API for type-aware dataset listing.
- Shows dataset type correctly in `dataset info`.
- Adds Linux-style aliases:
  - `pb dataset ls`
  - `pb dataset stat`

### SQL workflow

- Moves SQL to the top-level `pb sql` flow.
- Adds `pb sql save <query>` for saving queries directly.
- Adds default `LIMIT 500` when a SQL query has no top-level limit.
- Keeps user-provided limits unchanged.
- Improves SQL query normalization for quoted streams/fields.
- Improves saved query list behavior for empty/error responses.
- Adds `pb sql ls` alias.

### SQL interactive UI

- Reworks the SQL interactive layout around editor, time range, dataset, columns, and results.
- Adds an inline columns drawer with filtering and keyboard navigation.
- Adds UTC/local time display controls.
- Updates result timestamp rendering to follow the selected time display mode.
- Improves time range formatting and picker behavior.
- Keeps result/table area responsive when columns are hidden or unavailable.

### PromQL workflow

- Moves PromQL to the top-level `pb promql run` flow.
- Updates examples/help text away from the old query subcommand path.
- Reorders `pb promql --help` commands by priority, with `run` first.
- Adds `pb promql ps` alias for `active-queries`.

### PromQL interactive UI

- Applies the same pane naming and border treatment as SQL.
- Adds UTC/local time display support for PromQL results and charts.
- Fixes time picker behavior for range and instant modes.
- Prevents invalid/future time selections where applicable.
- Keeps time changes cancellable until explicitly confirmed.

### Auth and profiles

- Validates `pb login` credentials before saving a profile.
- Shows a clear login failure when credentials are invalid.
- Improves `pb logout` confirmation messaging.
- Handles default profile fallback after logout:
  - auto-selects the only remaining profile
  - opens a picker when multiple profiles remain
  - supports recovery when no default profile is currently set
- Makes auth/runtime errors cleaner by avoiding usage spam on list commands.

### Users and roles

- Improves `pb user list` and `pb role list` readability with aligned table output.
- Adds muted dotted leaders so users/roles are easier to scan.
- Adds Linux-style aliases:
  - `pb user ls`
  - `pb role ls`

### Command help and aliases

- Adds grouped root help output.
- Adds Linux-style aliases:
  - `pb profile ls`
  - `pb dataset ls`
  - `pb dataset stat`
  - `pb user ls`
  - `pb role ls`
  - `pb sql ls`
  - `pb promql ps`
- Keeps existing command names intact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dataset-type aware commands with interactive type selection.
  * Save and manage SQL queries via new save/apply commands.
  * Short `ls` aliases added for profile, user, role, and saved-query listing.
  * Time-display mode (UTC/local) toggle across PromQL and SQL UIs.

* **Improvements**
  * Consolidated query UX under `pb sql` and updated CLI examples.
  * Interactive PromQL defaults and improved SQL interactive behavior.
  * Confirm-on-logout and smarter default-profile handling.
  * Better table/text rendering and clearer auth error messages.

* **Tests**
  * Expanded unit tests for datasets, SQL normalization, PromQL, time inputs, and status handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->