### PR TITLE
chore: add Homebrew tap release automation

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -38,3 +38,8 @@ jobs:
           args: release --parallelism 1 --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Update Homebrew tap
+        env:
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
+        run: scripts/update-homebrew-tap.sh

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ curl -fsSL https://raw.githubusercontent.com/parseablehq/pb/main/scripts/install
 **Quick install (Windows PowerShell):**
 
 ```powershell
-irm https://raw.githubusercontent.com/parseablehq/pb/main/scripts/install.ps1 | iex
+powershell -ExecutionPolicy Bypass -c "irm https://raw.githubusercontent.com/parseablehq/pb/main/scripts/install.ps1 | iex"
 ```
 
 Downloads the latest release, verifies the SHA-256 checksum, installs to

--- a/scripts/update-homebrew-tap.sh
+++ b/scripts/update-homebrew-tap.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+version="${GITHUB_REF_NAME#v}"
+tap_dir="$(mktemp -d)"
+repo_url="https://x-access-token:${HOMEBREW_TAP_GITHUB_TOKEN}@github.com/parseablehq/homebrew-tap.git"
+
+git clone "$repo_url" "$tap_dir"
+mkdir -p "$tap_dir/Formula"
+
+sha256_file() {
+  shasum -a 256 "$1" | awk '{print $1}'
+}
+
+darwin_arm64_sha="$(sha256_file "dist/pb_${version}_darwin_arm64.tar.gz")"
+darwin_amd64_sha="$(sha256_file "dist/pb_${version}_darwin_amd64.tar.gz")"
+linux_arm64_sha="$(sha256_file "dist/pb_${version}_linux_arm64.tar.gz")"
+linux_amd64_sha="$(sha256_file "dist/pb_${version}_linux_amd64.tar.gz")"
+
+cat > "$tap_dir/Formula/pb.rb" <<EOF
+class Pb < Formula
+  desc "Command line interface for Parseable"
+  homepage "https://github.com/parseablehq/pb"
+  license "AGPL-3.0"
+  version "${version}"
+
+  on_macos do
+    on_arm do
+      url "https://github.com/parseablehq/pb/releases/download/v${version}/pb_${version}_darwin_arm64.tar.gz"
+      sha256 "${darwin_arm64_sha}"
+    end
+
+    on_intel do
+      url "https://github.com/parseablehq/pb/releases/download/v${version}/pb_${version}_darwin_amd64.tar.gz"
+      sha256 "${darwin_amd64_sha}"
+    end
+  end
+
+  on_linux do
+    on_arm do
+      url "https://github.com/parseablehq/pb/releases/download/v${version}/pb_${version}_linux_arm64.tar.gz"
+      sha256 "${linux_arm64_sha}"
+    end
+
+    on_intel do
+      url "https://github.com/parseablehq/pb/releases/download/v${version}/pb_${version}_linux_amd64.tar.gz"
+      sha256 "${linux_amd64_sha}"
+    end
+  end
+
+  def install
+    bin.install "pb"
+  end
+
+  test do
+    system "#{bin}/pb", "--help"
+  end
+end
+EOF
+
+git -C "$tap_dir" config user.name "github-actions[bot]"
+git -C "$tap_dir" config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+git -C "$tap_dir" add Formula/pb.rb
+
+if git -C "$tap_dir" diff --cached --quiet; then
+  echo "Homebrew formula is already up to date."
+else
+  git -C "$tap_dir" commit -m "Update pb to v${version}"
+  git -C "$tap_dir" push origin HEAD
+fi


### PR DESCRIPTION
## Summary

Adds Homebrew tap release automation and updates installation docs.

## Changes

- Adds `scripts/update-homebrew-tap.sh` to update [`parseablehq/homebrew-tap`](https://github.com/parseablehq/homebrew-tap)
- Updates the release workflow to run the Homebrew tap script after GoReleaser
- Generates `Formula/pb.rb` with macOS/Linux amd64 and arm64 release artifacts
- Computes SHA256 checksums from GoReleaser `dist/` artifacts
- Uses `shasum -a 256` for macOS/Linux-compatible checksum generation
- Skips committing when the formula is already up to date
- Fixes the Windows install command in README with the working command

## Notes

- Requires `HOMEBREW_TAP_GITHUB_TOKEN` repository secret with write access to `parseablehq/homebrew-tap`
- Windows is intentionally not included in the Homebrew formula
- Windows users continue to install via release archive / documented PowerShell flow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Homebrew package support for macOS and Linux installations, simplifying the installation process.

* **Documentation**
  * Updated Windows PowerShell installation instructions with improved command syntax for better compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->