### PR TITLE
update help with shortcuts

### DIFF
--- a/cmd/dataset.go
+++ b/cmd/dataset.go
@@ -54,12 +54,15 @@ type DatasetStatsData struct {
 
 type DatasetListItem struct {
 	Name string
+	Type string
+	LastIngested time.Time
 }
 
 func (item *DatasetListItem) Render() string {
 	bullet := SelectedStyle.Render("•")
 	name := StandardStyle.Render(item.Name)
-	return ItemOuter.Render(fmt.Sprintf("%s %s", bullet, name))
+	datasetType := StandardStyle.Render(item.Type)
+	return ItemOuter.Render(fmt.Sprintf("%s %s [%s]", bullet, name, datasetType))
 }
 
 // DatasetRetentionData is the data structure for dataset retention
@@ -459,7 +462,7 @@ func init() {
 }
 
 var RemoveDatasetCmd = &cobra.Command{
-	Use:          "remove dataset-name",
+	Use:          "remove|rm dataset-name",
 	Aliases:      []string{"rm"},
 	Example:      " pb dataset remove backend_logs\n pb dataset remove backend_logs --type logs",
 	Short:        "Delete a dataset",
@@ -546,7 +549,7 @@ func init() {
 
 // ListDatasetCmd is the list command for datasets
 var ListDatasetCmd = &cobra.Command{
-	Use:          "list",
+	Use:          "list|ls",
 	Aliases:      []string{"ls"},
 	Example:      "  pb dataset list",
 	Short:        "List all datasets",
@@ -577,7 +580,7 @@ var ListDatasetCmd = &cobra.Command{
 		}
 
 		for _, dataset := range items {
-			fmt.Println((&DatasetListItem{Name: dataset.Title}).Render())
+			fmt.Println((&DatasetListItem{Name: dataset.Title, Type: dataset.DatasetType}).Render())
 		}
 		return nil
 	},

--- a/cmd/dataset.go
+++ b/cmd/dataset.go
@@ -53,8 +53,8 @@ type DatasetStatsData struct {
 }
 
 type DatasetListItem struct {
-	Name string
-	Type string
+	Name         string
+	Type         string
 	LastIngested time.Time
 }
 

--- a/cmd/dataset.go
+++ b/cmd/dataset.go
@@ -62,6 +62,9 @@ func (item *DatasetListItem) Render() string {
 	bullet := SelectedStyle.Render("•")
 	name := StandardStyle.Render(item.Name)
 	datasetType := StandardStyle.Render(item.Type)
+	if datasetType == "" {
+		return ItemOuter.Render(fmt.Sprintf("%s %s", bullet, name))
+	}
 	return ItemOuter.Render(fmt.Sprintf("%s %s [%s]", bullet, name, datasetType))
 }
 

--- a/cmd/profile.go
+++ b/cmd/profile.go
@@ -154,7 +154,7 @@ var AddProfileCmd = &cobra.Command{
 }
 
 var RemoveProfileCmd = &cobra.Command{
-	Use:     "remove profile-name",
+	Use:     "remove|rm profile-name",
 	Aliases: []string{"rm"},
 	Example: "  pb profile remove local_parseable",
 	Args:    cobra.ExactArgs(1),
@@ -328,7 +328,7 @@ var UpdateProfileCmd = &cobra.Command{
 }
 
 var ListProfileCmd = &cobra.Command{
-	Use:     "list profiles",
+	Use:     "list|ls profiles",
 	Aliases: []string{"ls"},
 	Short:   "List all added profiles",
 	Example: "  pb profile list",

--- a/cmd/queryList.go
+++ b/cmd/queryList.go
@@ -30,7 +30,7 @@ import (
 )
 
 var SavedQueryList = &cobra.Command{
-	Use:          "list",
+	Use:          "list|ls",
 	Aliases:      []string{"ls"},
 	Example:      "pb sql list [-o | --output]",
 	Short:        "List of saved queries",

--- a/cmd/role.go
+++ b/cmd/role.go
@@ -143,7 +143,7 @@ var AddRoleCmd = &cobra.Command{
 }
 
 var RemoveRoleCmd = &cobra.Command{
-	Use:     "remove role-name",
+	Use:     "remove|rm role-name",
 	Aliases: []string{"rm"},
 	Example: "  pb role remove ingestor",
 	Short:   "Delete a role",
@@ -188,7 +188,7 @@ var RemoveRoleCmd = &cobra.Command{
 }
 
 var ListRoleCmd = &cobra.Command{
-	Use:          "list",
+	Use:          "list|ls",
 	Aliases:      []string{"ls"},
 	Short:        "List all roles",
 	Example:      "  pb role list",

--- a/cmd/user.go
+++ b/cmd/user.go
@@ -149,7 +149,7 @@ var AddUserCmd = func() *cobra.Command {
 }()
 
 var RemoveUserCmd = &cobra.Command{
-	Use:     "remove user-name",
+	Use:     "remove|rm user-name",
 	Aliases: []string{"rm"},
 	Example: "  pb user remove bob",
 	Short:   "Delete a user",
@@ -275,7 +275,7 @@ var SetUserRoleCmd = &cobra.Command{
 }
 
 var ListUserCmd = &cobra.Command{
-	Use:          "list",
+	Use:          "list|ls",
 	Aliases:      []string{"ls"},
 	Short:        "List all users",
 	Example:      "  pb user list",

--- a/pkg/model/query.go
+++ b/pkg/model/query.go
@@ -1641,7 +1641,7 @@ func renderSQLControlsBox(start, end, dataset string, columns []string, columnId
 		paneRule("┌", "┐", "TIME RANGE "+formatResultTimeLabel(displayMode), width, borderStyle, timeTitleStyle),
 	}
 	lines = append(lines, paneBodyLines(lipgloss.JoinVertical(lipgloss.Left, timeLines...), width, len(timeLines), borderStyle)...)
-	lines = append(lines, paneRule("├", "┤", "DATASET", width, borderStyle, datasetTitleStyle))
+	lines = append(lines, paneRule("├", "┤", "DATASET <ctrl-d>", width, borderStyle, datasetTitleStyle))
 	lines = append(lines, paneBodyLines(lipgloss.JoinVertical(lipgloss.Left, datasetLines...), width, len(datasetLines), borderStyle)...)
 	lines = append(lines, paneRule("├", "┤", columnsTitle, width, borderStyle, columnsTitleStyle))
 	lines = append(lines, paneBodyLines(lipgloss.JoinVertical(lipgloss.Left, columnLines...), width, columnSectionH, borderStyle)...)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dataset list now shows dataset type and last-ingested timestamp alongside names
  * SQL sidebar dataset header now includes a Ctrl‑D shortcut hint

* **Improvements**
  * CLI help now consistently advertises common aliases (e.g., "remove|rm", "list|ls") for user, profile, role, and dataset commands
<!-- end of auto-generated comment: release notes by coderabbit.ai -->