### PR TITLE
fix: cleanUp config and removed the ingestUrl

### DIFF
--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -58,7 +58,6 @@ type cloudAPIKeyValidationResponse struct {
 	WorkspaceName string `json:"workspace_name"`
 	TenantID      string `json:"tenant_id"`
 	URL           string `json:"url"`
-	IngestURL     string `json:"ingest_url"`
 	State         string `json:"state"`
 	MultiTenant   bool   `json:"multi_tenant"`
 }
@@ -228,7 +227,6 @@ var CloudProfileAddCmd = &cobra.Command{
 			Cloud:           true,
 			APIKey:          apiKey,
 			TenantID:        result.TenantID,
-			IngestURL:       result.IngestURL,
 			WorkspaceID:     result.WorkspaceID,
 			WorkspaceName:   result.WorkspaceName,
 			OrchestratorURL: orchestratorURL,

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -88,7 +88,6 @@ func cloudProfileFromAPIKey(ctx context.Context, apiKey string) (*config.Profile
 		Cloud:           true,
 		APIKey:          apiKey,
 		TenantID:        result.TenantID,
-		IngestURL:       result.IngestURL,
 		WorkspaceID:     result.WorkspaceID,
 		WorkspaceName:   result.WorkspaceName,
 		OrchestratorURL: orchestratorURL,

--- a/cmd/profile.go
+++ b/cmd/profile.go
@@ -40,7 +40,6 @@ type profileOutput struct {
 	Username        string `json:"username,omitempty"`
 	Cloud           bool   `json:"cloud"`
 	TenantID        string `json:"tenant_id,omitempty"`
-	IngestURL       string `json:"ingest_url,omitempty"`
 	WorkspaceID     string `json:"workspace_id,omitempty"`
 	WorkspaceName   string `json:"workspace_name,omitempty"`
 	OrchestratorURL string `json:"orchestrator_url,omitempty"`
@@ -52,7 +51,6 @@ func safeProfileOutput(profile config.Profile) profileOutput {
 		Username:        profile.Username,
 		Cloud:           profile.Cloud,
 		TenantID:        profile.TenantID,
-		IngestURL:       profile.IngestURL,
 		WorkspaceID:     profile.WorkspaceID,
 		WorkspaceName:   profile.WorkspaceName,
 		OrchestratorURL: profile.OrchestratorURL,

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -98,7 +98,6 @@ type Profile struct {
 	SessionToken    string `toml:"session_token,omitempty" json:"session_token,omitempty"`
 	RefreshToken    string `toml:"refresh_token,omitempty" json:"refresh_token,omitempty"`
 	TenantID        string `toml:"tenant_id,omitempty" json:"tenant_id,omitempty"`
-	IngestURL       string `toml:"ingest_url,omitempty" json:"ingest_url,omitempty"`
 	WorkspaceID     string `toml:"workspace_id,omitempty" json:"workspace_id,omitempty"`
 	WorkspaceName   string `toml:"workspace_name,omitempty" json:"workspace_name,omitempty"`
 	OrchestratorURL string `toml:"orchestrator_url,omitempty" json:"orchestrator_url,omitempty"`


### PR DESCRIPTION
### Clean Up
- removed the ingest conifig from the pb config.go

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Simplified cloud profile configuration by removing the obsolete ingest URL field.
  * Updated profile validation and authentication data handling to use the profile URL, workspace details, tenant information, and token settings.
  * Removed ingest URL values from safe profile output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->