### PR TITLE
Feat/agent ready cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,10 +373,6 @@ Errors use a stable envelope such as:
 line; it requires the server's gRPC port to be reachable and can be stopped
 with Ctrl+C.
 
-For agent-run SQL, allow only `SELECT` queries and never use `--save-as`, which
-writes a query to the local profile. Use `pb sql list -o json` to list saved
-queries without opening a terminal UI.
-
 > ⚠️ **Warning for agent access:** Create a dedicated read-only API key or role
 > with the minimum permissions required for queries and metadata reads. Do not
 > give an agent an administrator or shared human credential. Read-only access

--- a/README.md
+++ b/README.md
@@ -362,24 +362,16 @@ Use `pb <command> --help` to check output support. For automation, omit `-i`
 so SQL and PromQL commands print output instead of opening the terminal UI.
 Empty collections are encoded as `[]`, not `null`.
 
-In JSON mode, successful results go to stdout, diagnostics and structured
-errors go to stderr, and failures return a non-zero exit status. This keeps
-redirected result files safe to parse:
-
-```bash
-pb dataset list -o json >data.json 2>errors.json
-```
-
 Errors use a stable envelope such as:
 
 ```json
 {"error":{"code":"NOT_FOUND","message":"profile not found","retryable":false}}
 ```
 
-`pb status -o json` is the deliberate exception: an unhealthy status document
-is written to stdout and the process exits non-zero. `pb tail <dataset> -o json`
-is a long-running stream with one JSON value per line; it requires the server's
-gRPC port to be reachable and can be stopped with Ctrl+C.
+`pb status -o json` returns a non-zero exit status when the server is unhealthy.
+`pb tail <dataset> -o json` is a long-running stream with one JSON value per
+line; it requires the server's gRPC port to be reachable and can be stopped
+with Ctrl+C.
 
 For agent-run SQL, allow only `SELECT` queries and never use `--save-as`, which
 writes a query to the local profile. Use `pb sql list -o json` to list saved

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ On macOS, a manually downloaded binary may be blocked on first run. Allow it onc
 
 ```bash
 xattr -d com.apple.quarantine /usr/local/bin/pb
+```
 
 **Verify:** `pb --help`
 
@@ -333,19 +334,56 @@ pb promql ps
 
 ## Automation
 
-Commands print human-readable text by default. Commands that support
-`-o json` return structured output for scripts, CI, and agent workflows:
+Commands print human-readable text by default. For scripts, CI, and agents,
+start by discovering the read-only command catalog and machine-readable help:
+
+```bash
+pb agent -o json
+pb -o json
+pb help dataset list -o json
+```
+
+The agent catalog contains only read-only commands. It also records arguments,
+flags, required permissions, and safety constraints. Server-side permissions
+remain authoritative.
+
+Commands that support `-o json` return structured output:
 
 ```bash
 pb status -o json
 pb profile list -o json
 pb dataset list -o json
+pb sql list -o json
 pb sql run "SELECT count(*) FROM backend" --from=1h --output json
 pb promql run "up" --dataset otel_metrics --instant --output json
 ```
 
 Use `pb <command> --help` to check output support. For automation, omit `-i`
 so SQL and PromQL commands print output instead of opening the terminal UI.
+Empty collections are encoded as `[]`, not `null`.
+
+In JSON mode, successful results go to stdout, diagnostics and structured
+errors go to stderr, and failures return a non-zero exit status. This keeps
+redirected result files safe to parse:
+
+```bash
+pb dataset list -o json >data.json 2>errors.json
+```
+
+Errors use a stable envelope such as:
+
+```json
+{"error":{"code":"NOT_FOUND","message":"profile not found","retryable":false}}
+```
+
+`pb status -o json` is the deliberate exception: an unhealthy status document
+is written to stdout and the process exits non-zero. `pb tail <dataset> -o json`
+is a long-running stream with one JSON value per line; it requires the server's
+gRPC port to be reachable and can be stopped with Ctrl+C.
+
+For agent-run SQL, allow only `SELECT` queries and never use `--save-as`, which
+writes a query to the local profile. Use `pb sql list -o json` to list saved
+queries without opening a terminal UI.
 
 > ⚠️ **Warning for agent access:** Create a dedicated read-only API key or role
 > with the minimum permissions required for queries and metadata reads. Do not

--- a/README.md
+++ b/README.md
@@ -343,8 +343,8 @@ pb -o json
 pb help dataset list -o json
 ```
 
-The agent catalog contains only read-only commands. It also records arguments,
-flags, required permissions, and safety constraints. Server-side permissions
+The agent catalog contains only read-only commands. It records command strings,
+scope, profile requirements, and safety constraints. Server-side permissions
 remain authoritative.
 
 Commands that support `-o json` return structured output:

--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -1,0 +1,127 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+type agentManifest struct {
+	SchemaVersion string           `json:"schema_version"`
+	Catalog       string           `json:"catalog"`
+	Authorization string           `json:"authorization"`
+	Contract      agentContract    `json:"contract"`
+	ErrorCodes    []agentErrorCode `json:"error_codes"`
+	Commands      []agentCommand   `json:"commands"`
+	Excluded      string           `json:"excluded"`
+}
+
+type agentContract struct {
+	SuccessOutput string   `json:"success_output"`
+	ErrorOutput   string   `json:"error_output"`
+	Diagnostics   string   `json:"diagnostics"`
+	FailureExit   string   `json:"failure_exit"`
+	EmptyLists    string   `json:"empty_lists"`
+	SpecialCases  []string `json:"special_cases,omitempty"`
+}
+
+type agentErrorCode struct {
+	Code      ErrorCode `json:"code"`
+	Retryable bool      `json:"retryable"`
+}
+
+type agentCommand struct {
+	Command         string   `json:"command"`
+	Description     string   `json:"description"`
+	Scope           string   `json:"scope"`
+	Mutates         bool     `json:"mutates"`
+	RequiresProfile bool     `json:"requires_profile"`
+	Streaming       bool     `json:"streaming,omitempty"`
+	Constraints     []string `json:"constraints,omitempty"`
+}
+
+// AgentCmd describes the machine-readable, read-only CLI surface available to agents.
+var AgentCmd = &cobra.Command{
+	Use:     "agent",
+	Short:   "Show the read-only command catalog for agents",
+	Example: "  pb agent -o json",
+	Args:    cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		format, err := commandOutputFormat(cmd)
+		if err != nil {
+			return err
+		}
+		manifest := newAgentManifest()
+		if format == outputJSON {
+			return writeJSON(cmd.OutOrStdout(), manifest)
+		}
+
+		out := cmd.OutOrStdout()
+		fmt.Fprintln(out, "Read-only command catalog for agents")
+		fmt.Fprintln(out, manifest.Authorization)
+		for _, item := range manifest.Commands {
+			fmt.Fprintf(out, "- %s: %s\n", item.Command, item.Description)
+		}
+		return nil
+	},
+}
+
+func init() {
+	AgentCmd.Flags().StringP("output", "o", "text", "Output format (text|json)")
+}
+
+func newAgentManifest() agentManifest {
+	return agentManifest{
+		SchemaVersion: "1",
+		Catalog:       "cli-declared read-only commands",
+		Authorization: "The server still enforces the active profile's permissions; inclusion here does not guarantee authorization.",
+		Contract: agentContract{
+			SuccessOutput: "stdout",
+			ErrorOutput:   "stderr as JSON when -o json is explicit",
+			Diagnostics:   "stderr",
+			FailureExit:   "non-zero",
+			EmptyLists:    "[]",
+			SpecialCases: []string{
+				"pb status -o json reports an unhealthy status as JSON on stdout and exits non-zero",
+			},
+		},
+		ErrorCodes: []agentErrorCode{
+			{Code: ErrorInvalidInput, Retryable: false},
+			{Code: ErrorAuthFailed, Retryable: false},
+			{Code: ErrorPermissionDenied, Retryable: false},
+			{Code: ErrorNotFound, Retryable: false},
+			{Code: ErrorConflict, Retryable: false},
+			{Code: ErrorRateLimited, Retryable: true},
+			{Code: ErrorConnectionFailed, Retryable: true},
+			{Code: ErrorTimeout, Retryable: true},
+			{Code: ErrorInvalidResponse, Retryable: false},
+			{Code: ErrorServer, Retryable: true},
+			{Code: ErrorCommandFailed, Retryable: false},
+		},
+		Commands: []agentCommand{
+			{Command: "pb agent -o json", Description: "Discover this agent contract and command catalog", Scope: "local", Mutates: false, RequiresProfile: false},
+			{Command: "pb -o json", Description: "Discover the complete reachable CLI command tree and flags", Scope: "local", Mutates: false, RequiresProfile: false},
+			{Command: "pb help <command...> -o json", Description: "Inspect one command and its flags or subcommands", Scope: "local", Mutates: false, RequiresProfile: false},
+			{Command: "pb status -o json", Description: "Check the active profile and server connection", Scope: "local+server", Mutates: false, RequiresProfile: false},
+			{Command: "pb version -o json", Description: "Show client and connected-server versions", Scope: "local+server", Mutates: false, RequiresProfile: true},
+			{Command: "pb profile list -o json", Description: "List locally configured profiles without credentials", Scope: "local", Mutates: false, RequiresProfile: false, Constraints: []string{"Requires the local pb config file"}},
+			{Command: "pb dataset list -o json", Description: "List datasets", Scope: "server", Mutates: false, RequiresProfile: true},
+			{Command: "pb dataset info <dataset> -o json", Description: "Read dataset statistics and configuration", Scope: "server", Mutates: false, RequiresProfile: true},
+			{Command: "pb user list -o json", Description: "List users and their roles", Scope: "server", Mutates: false, RequiresProfile: true},
+			{Command: "pb role list -o json", Description: "List roles and privileges", Scope: "server", Mutates: false, RequiresProfile: true},
+			{Command: "pb sql run \"<SELECT query>\" --from <time> --to <time> -o json", Description: "Run a read-only SQL query", Scope: "server", Mutates: false, RequiresProfile: true, Constraints: []string{"Use SELECT-only SQL", "Never use --save-as because it creates a saved query"}},
+			{Command: "pb sql list -o json", Description: "List saved SQL queries without opening the TUI", Scope: "server", Mutates: false, RequiresProfile: true},
+			{Command: "pb promql run \"<expression>\" --dataset <dataset> -o json", Description: "Run a PromQL query", Scope: "server", Mutates: false, RequiresProfile: true},
+			{Command: "pb promql labels <dataset> -o json", Description: "List PromQL label names", Scope: "server", Mutates: false, RequiresProfile: true},
+			{Command: "pb promql label-values <label> <dataset> -o json", Description: "List values for a PromQL label", Scope: "server", Mutates: false, RequiresProfile: true},
+			{Command: "pb promql series <dataset> --match <selector> -o json", Description: "List matching PromQL series", Scope: "server", Mutates: false, RequiresProfile: true},
+			{Command: "pb promql cardinality label-names <dataset> -o json", Description: "Inspect label-name cardinality", Scope: "server", Mutates: false, RequiresProfile: true},
+			{Command: "pb promql cardinality label-values <dataset> <label> -o json", Description: "Inspect label-value cardinality", Scope: "server", Mutates: false, RequiresProfile: true},
+			{Command: "pb promql cardinality active-series <dataset> <selector> -o json", Description: "Inspect active-series cardinality", Scope: "server", Mutates: false, RequiresProfile: true},
+			{Command: "pb promql active-queries -o json", Description: "List active PromQL queries", Scope: "server", Mutates: false, RequiresProfile: true},
+			{Command: "pb promql tsdb <dataset> -o json", Description: "Read PromQL TSDB statistics", Scope: "server", Mutates: false, RequiresProfile: true},
+			{Command: "pb tail <dataset> -o json", Description: "Stream live dataset events until interrupted", Scope: "server", Mutates: false, RequiresProfile: true, Streaming: true, Constraints: []string{"Long-running command; stop with SIGINT"}},
+		},
+		Excluded: "Commands that add, update, save, set, remove, delete, install, or uninstall resources are intentionally omitted.",
+	}
+}

--- a/cmd/agent_test.go
+++ b/cmd/agent_test.go
@@ -1,0 +1,69 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestAgentManifestContainsOnlyReadOnlyCommands(t *testing.T) {
+	manifest := newAgentManifest()
+	if manifest.SchemaVersion != "1" || len(manifest.Commands) == 0 {
+		t.Fatalf("unexpected manifest metadata: %+v", manifest)
+	}
+
+	seen := make(map[string]struct{}, len(manifest.Commands))
+	for _, item := range manifest.Commands {
+		if item.Mutates {
+			t.Fatalf("mutating command included in agent catalog: %s", item.Command)
+		}
+		if !strings.Contains(item.Command, "-o json") {
+			t.Fatalf("agent command does not request JSON: %s", item.Command)
+		}
+		if _, exists := seen[item.Command]; exists {
+			t.Fatalf("duplicate agent command: %s", item.Command)
+		}
+		seen[item.Command] = struct{}{}
+	}
+	for _, command := range []string{"pb -o json", "pb help <command...> -o json", "pb dataset list -o json", "pb sql list -o json", "pb promql active-queries -o json"} {
+		if _, exists := seen[command]; !exists {
+			t.Fatalf("read-only command missing from agent catalog: %s", command)
+		}
+	}
+	var sqlCommand agentCommand
+	for _, item := range manifest.Commands {
+		if item.Command == "pb sql run \"<SELECT query>\" --from <time> --to <time> -o json" {
+			sqlCommand = item
+			break
+		}
+	}
+	constraints := strings.Join(sqlCommand.Constraints, " ")
+	if !strings.Contains(constraints, "SELECT-only") || !strings.Contains(constraints, "--save-as") {
+		t.Fatalf("SQL agent safety constraints are incomplete: %v", sqlCommand.Constraints)
+	}
+}
+
+func TestAgentCommandJSONDoesNotRequireProfile(t *testing.T) {
+	if err := AgentCmd.Flags().Set("output", "json"); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = AgentCmd.Flags().Set("output", "text")
+		AgentCmd.SetOut(nil)
+	})
+
+	var output bytes.Buffer
+	AgentCmd.SetOut(&output)
+	if err := AgentCmd.RunE(AgentCmd, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	var manifest agentManifest
+	if err := json.Unmarshal(output.Bytes(), &manifest); err != nil {
+		t.Fatalf("invalid JSON output: %v\n%s", err, output.String())
+	}
+	if len(manifest.Commands) == 0 || manifest.Contract.SuccessOutput != "stdout" {
+		t.Fatalf("incomplete agent manifest: %+v", manifest)
+	}
+}

--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -208,8 +208,9 @@ var CloudProfileAddCmd = &cobra.Command{
 		if apiKey == "" {
 			return errors.New("api key is required. pass --api-key")
 		}
-		if cloudOutputFormat != "text" && cloudOutputFormat != "json" {
-			return fmt.Errorf("unsupported output format %q (expected text or json)", cloudOutputFormat)
+		outputFormat, err := validateOutputFormat(cloudOutputFormat)
+		if err != nil {
+			return err
 		}
 
 		orchestratorURL := cloudOrchestratorEndpoint()
@@ -235,7 +236,7 @@ var CloudProfileAddCmd = &cobra.Command{
 			return err
 		}
 
-		if cloudOutputFormat == "json" {
+		if outputFormat == "json" {
 			return json.NewEncoder(cmd.OutOrStdout()).Encode(cloudProfileAddOutput{
 				Status:  "success",
 				Name:    profileName,

--- a/cmd/dataset.go
+++ b/cmd/dataset.go
@@ -168,23 +168,22 @@ var AddDatasetCmd = &cobra.Command{
 			cmd.Annotations["errors"] = fmt.Sprintf("Error: %s", err.Error())
 			return err
 		}
+		defer resp.Body.Close()
 
 		// Capture execution time
 		cmd.Annotations["executionTime"] = time.Since(startTime).String()
 
-		if resp.StatusCode == 200 {
-			fmt.Printf("Created %s dataset %s\n", SelectedStyle.Render(datasetType), StyleBold.Render(name))
-		} else {
-			bytes, err := io.ReadAll(resp.Body)
+		if resp.StatusCode != http.StatusOK {
+			body, err := io.ReadAll(resp.Body)
 			if err != nil {
 				cmd.Annotations["errors"] = fmt.Sprintf("Error: %s", err.Error())
 				return err
 			}
-			body := string(bytes)
-			defer resp.Body.Close()
-			fmt.Printf("Request Failed\nStatus Code: %s\nResponse: %s\n", resp.Status, body)
+			requestErr := responseStatusError("create dataset", resp.StatusCode, resp.Status, body)
+			cmd.Annotations["errors"] = requestErr.Error()
+			return requestErr
 		}
-
+		fmt.Printf("Created %s dataset %s\n", SelectedStyle.Render(datasetType), StyleBold.Render(name))
 		return nil
 	},
 }
@@ -386,8 +385,11 @@ var StatDatasetCmd = &cobra.Command{
 		}
 
 		// Check output format
-		output, _ := cmd.Flags().GetString("output")
-		if output == "json" {
+		output, err := commandOutputFormat(cmd)
+		if err != nil {
+			return err
+		}
+		if output == outputJSON {
 			// Prepare JSON response
 			data := map[string]interface{}{
 				"info": map[string]interface{}{
@@ -397,17 +399,14 @@ var StatDatasetCmd = &cobra.Command{
 					"compression_ratio": fmt.Sprintf("%.2f%%", compressionRatio),
 				},
 				"retention":    retention,
-				"alerts":       alertsData.Alerts,
+				"alerts":       nonNilSlice(alertsData.Alerts),
 				"dataset_type": datasetType,
 			}
 
-			jsonData, err := json.MarshalIndent(data, "", "  ")
-			if err != nil {
-				// Capture error
+			if err := writeJSON(cmd.OutOrStdout(), data); err != nil {
 				cmd.Annotations["errors"] = fmt.Sprintf("Error: %s", err.Error())
 				return err
 			}
-			fmt.Println(string(jsonData))
 		} else {
 			// Default text output
 			isRetentionSet := len(retention) > 0
@@ -518,23 +517,22 @@ var RemoveDatasetCmd = &cobra.Command{
 			cmd.Annotations["errors"] = fmt.Sprintf("Error: %s", err.Error())
 			return err
 		}
+		defer resp.Body.Close()
 
 		// Capture execution time
 		cmd.Annotations["executionTime"] = time.Since(startTime).String()
 
-		if resp.StatusCode == 200 {
-			fmt.Printf("Successfully deleted dataset %s\n", StyleBold.Render(name))
-		} else {
-			bytes, err := io.ReadAll(resp.Body)
+		if resp.StatusCode != http.StatusOK {
+			body, err := io.ReadAll(resp.Body)
 			if err != nil {
 				cmd.Annotations["errors"] = fmt.Sprintf("Error: %s", err.Error())
 				return err
 			}
-			body := string(bytes)
-			defer resp.Body.Close()
-			fmt.Printf("Request Failed\nStatus Code: %s\nResponse: %s\n", resp.Status, body)
+			requestErr := responseStatusError("delete dataset", resp.StatusCode, resp.Status, body)
+			cmd.Annotations["errors"] = requestErr.Error()
+			return requestErr
 		}
-
+		fmt.Printf("Successfully deleted dataset %s\n", StyleBold.Render(name))
 		return nil
 	},
 }
@@ -571,15 +569,15 @@ var ListDatasetCmd = &cobra.Command{
 			return err
 		}
 
-		output, _ := cmd.Flags().GetString("output")
-		if output == "json" {
-			jsonData, err := json.MarshalIndent(items, "", "  ")
-			if err != nil {
-				cmd.Annotations["errors"] = fmt.Sprintf("Error: %s", err.Error())
-				return err
+		output, err := commandOutputFormat(cmd)
+		if err != nil {
+			return err
+		}
+		if output == outputJSON {
+			if items == nil {
+				items = []datasets.Dataset{}
 			}
-			fmt.Println(string(jsonData))
-			return nil
+			return writeJSON(cmd.OutOrStdout(), items)
 		}
 
 		for _, dataset := range items {
@@ -617,7 +615,8 @@ func fetchStats(client *internalHTTP.HTTPClient, name string) (data DatasetStats
 	case http.StatusNotFound:
 		// stream exists but has no stats yet (empty stream)
 	default:
-		err = fmt.Errorf("Request Failed\nStatus Code: %s\nResponse: %s\n", resp.Status, string(bytes))
+		legacyMessage := fmt.Sprintf("Request Failed\nStatus Code: %s\nResponse: %s\n", resp.Status, string(bytes))
+		err = httpStatusCLIError(resp.StatusCode, legacyMessage, fmt.Sprintf("request failed: %s", resp.Status))
 	}
 	return
 }
@@ -645,7 +644,8 @@ func fetchRetention(client *internalHTTP.HTTPClient, name string) (data DatasetR
 	case http.StatusNotFound:
 		// no retention configured
 	default:
-		err = fmt.Errorf("Request Failed\nStatus Code: %s\nResponse: %s\n", resp.Status, string(bytes))
+		legacyMessage := fmt.Sprintf("Request Failed\nStatus Code: %s\nResponse: %s\n", resp.Status, string(bytes))
+		err = httpStatusCLIError(resp.StatusCode, legacyMessage, fmt.Sprintf("request failed: %s", resp.Status))
 	}
 	return
 }
@@ -673,7 +673,8 @@ func fetchAlerts(client *internalHTTP.HTTPClient, name string) (data AlertConfig
 	case http.StatusNotFound:
 		// no alerts configured
 	default:
-		err = fmt.Errorf("Request Failed\nStatus Code: %s\nResponse: %s\n", resp.Status, string(bytes))
+		legacyMessage := fmt.Sprintf("Request Failed\nStatus Code: %s\nResponse: %s\n", resp.Status, string(bytes))
+		err = httpStatusCLIError(resp.StatusCode, legacyMessage, fmt.Sprintf("request failed: %s", resp.Status))
 	}
 	return
 }
@@ -717,9 +718,11 @@ func fetchInfo(client *internalHTTP.HTTPClient, name string) (datasetType string
 		}
 		return response.StreamType, nil
 	case http.StatusNotFound:
-		return "", fmt.Errorf("dataset %q not found", name)
+		message := fmt.Sprintf("dataset %q not found", name)
+		return "", httpStatusCLIError(resp.StatusCode, message, message)
 	default:
 		// Handle non-200 responses
-		return "", fmt.Errorf("Request Failed\nStatus Code: %d\nResponse: %s\n", resp.StatusCode, string(bytes))
+		legacyMessage := fmt.Sprintf("Request Failed\nStatus Code: %d\nResponse: %s\n", resp.StatusCode, string(bytes))
+		return "", httpStatusCLIError(resp.StatusCode, legacyMessage, fmt.Sprintf("request failed: %s", resp.Status))
 	}
 }

--- a/cmd/diagnostics_test.go
+++ b/cmd/diagnostics_test.go
@@ -21,6 +21,13 @@ func TestSQLMissingQueryReturnsErrorWithoutStdout(t *testing.T) {
 		query.SetOut(nil)
 		query.SetErr(nil)
 	})
+	interactiveFlag := query.Flags().Lookup("interactive")
+	previousInteractive := interactiveFlag.Value.String()
+	previousInteractiveChanged := interactiveFlag.Changed
+	t.Cleanup(func() {
+		_ = interactiveFlag.Value.Set(previousInteractive)
+		interactiveFlag.Changed = previousInteractiveChanged
+	})
 	if err := query.Flags().Set("interactive", "false"); err != nil {
 		t.Fatal(err)
 	}
@@ -43,6 +50,13 @@ func TestPromqlMissingExpressionReturnsErrorWithoutStdout(t *testing.T) {
 	t.Cleanup(func() {
 		promqlRunCmd.SetOut(nil)
 		promqlRunCmd.SetErr(nil)
+	})
+	interactiveFlag := promqlRunCmd.Flags().Lookup("interactive")
+	previousInteractive := interactiveFlag.Value.String()
+	previousInteractiveChanged := interactiveFlag.Changed
+	t.Cleanup(func() {
+		_ = interactiveFlag.Value.Set(previousInteractive)
+		interactiveFlag.Changed = previousInteractiveChanged
 	})
 	if err := promqlRunCmd.Flags().Set("interactive", "false"); err != nil {
 		t.Fatal(err)
@@ -68,6 +82,13 @@ func TestPromqlDecodeFailureDoesNotWriteRawBodyToStdout(t *testing.T) {
 	originalProfile := DefaultProfile
 	DefaultProfile = config.Profile{URL: server.URL, APIKey: "test-key"}
 	t.Cleanup(func() { DefaultProfile = originalProfile })
+	outputFlag := promqlLabelsCmd.Flags().Lookup("output")
+	previousOutput := outputFlag.Value.String()
+	previousOutputChanged := outputFlag.Changed
+	t.Cleanup(func() {
+		_ = outputFlag.Value.Set(previousOutput)
+		outputFlag.Changed = previousOutputChanged
+	})
 	if err := promqlLabelsCmd.Flags().Set("output", "text"); err != nil {
 		t.Fatal(err)
 	}
@@ -88,6 +109,9 @@ func TestPromqlDecodeFailureDoesNotWriteRawBodyToStdout(t *testing.T) {
 	}
 	if commandErr == nil || !strings.Contains(commandErr.Error(), "failed to decode") {
 		t.Fatalf("expected decode error, got %v", commandErr)
+	}
+	if detail := errorDetails(commandErr); detail.Code != ErrorInvalidResponse || detail.Retryable {
+		t.Fatalf("unexpected decode-error classification: %+v", detail)
 	}
 	if len(output) != 0 {
 		t.Fatalf("raw response leaked to stdout: %q", output)

--- a/cmd/diagnostics_test.go
+++ b/cmd/diagnostics_test.go
@@ -1,0 +1,95 @@
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/parseablehq/pb/pkg/config"
+)
+
+func TestSQLMissingQueryReturnsErrorWithoutStdout(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	query.SetOut(&stdout)
+	query.SetErr(&stderr)
+	t.Cleanup(func() {
+		query.SetOut(nil)
+		query.SetErr(nil)
+	})
+	if err := query.Flags().Set("interactive", "false"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := query.RunE(query, nil); err == nil || !strings.Contains(err.Error(), "SQL query is required") {
+		t.Fatalf("expected missing query error, got %v", err)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("unexpected stdout: %q", stdout.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("RunE should return diagnostics, not print them directly: %q", stderr.String())
+	}
+}
+
+func TestPromqlMissingExpressionReturnsErrorWithoutStdout(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	promqlRunCmd.SetOut(&stdout)
+	promqlRunCmd.SetErr(&stderr)
+	t.Cleanup(func() {
+		promqlRunCmd.SetOut(nil)
+		promqlRunCmd.SetErr(nil)
+	})
+	if err := promqlRunCmd.Flags().Set("interactive", "false"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := promqlRunCmd.RunE(promqlRunCmd, nil); err == nil || !strings.Contains(err.Error(), "PromQL expression is required") {
+		t.Fatalf("expected missing expression error, got %v", err)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("unexpected stdout: %q", stdout.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("RunE should return diagnostics, not print them directly: %q", stderr.String())
+	}
+}
+
+func TestPromqlDecodeFailureDoesNotWriteRawBodyToStdout(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, "not-json")
+	}))
+	defer server.Close()
+
+	originalProfile := DefaultProfile
+	DefaultProfile = config.Profile{URL: server.URL, APIKey: "test-key"}
+	t.Cleanup(func() { DefaultProfile = originalProfile })
+	if err := promqlLabelsCmd.Flags().Set("output", "text"); err != nil {
+		t.Fatal(err)
+	}
+
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	originalStdout := os.Stdout
+	os.Stdout = writer
+	commandErr := promqlLabelsCmd.RunE(promqlLabelsCmd, nil)
+	_ = writer.Close()
+	os.Stdout = originalStdout
+	output, readErr := io.ReadAll(reader)
+	_ = reader.Close()
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if commandErr == nil || !strings.Contains(commandErr.Error(), "failed to decode") {
+		t.Fatalf("expected decode error, got %v", commandErr)
+	}
+	if len(output) != 0 {
+		t.Fatalf("raw response leaked to stdout: %q", output)
+	}
+}

--- a/cmd/errors.go
+++ b/cmd/errors.go
@@ -1,0 +1,187 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"net"
+	"net/http"
+	"strings"
+)
+
+type ErrorCode string
+
+const (
+	// ErrorInvalidInput indicates invalid command arguments or request input.
+	ErrorInvalidInput ErrorCode = "INVALID_INPUT"
+	// ErrorAuthFailed indicates failed authentication.
+	ErrorAuthFailed ErrorCode = "AUTH_FAILED"
+	// ErrorPermissionDenied indicates insufficient authorization.
+	ErrorPermissionDenied ErrorCode = "PERMISSION_DENIED"
+	// ErrorNotFound indicates a missing resource.
+	ErrorNotFound ErrorCode = "NOT_FOUND"
+	// ErrorConflict indicates a resource state conflict.
+	ErrorConflict ErrorCode = "CONFLICT"
+	// ErrorRateLimited indicates server-side rate limiting.
+	ErrorRateLimited ErrorCode = "RATE_LIMITED"
+	// ErrorConnectionFailed indicates a network connection failure.
+	ErrorConnectionFailed ErrorCode = "CONNECTION_FAILED"
+	// ErrorTimeout indicates that an operation timed out.
+	ErrorTimeout ErrorCode = "TIMEOUT"
+	// ErrorInvalidResponse indicates malformed server output.
+	ErrorInvalidResponse ErrorCode = "INVALID_RESPONSE"
+	// ErrorServer indicates a server-side failure.
+	ErrorServer ErrorCode = "SERVER_ERROR"
+	// ErrorCommandFailed indicates an otherwise unclassified command failure.
+	ErrorCommandFailed ErrorCode = "COMMAND_FAILED"
+)
+
+type CLIError struct {
+	Code          ErrorCode
+	Message       string
+	PublicMessage string
+	HTTPStatus    int
+	Retryable     bool
+	Cause         error
+}
+
+func (err *CLIError) Error() string {
+	return err.Message
+}
+
+func (err *CLIError) Unwrap() error {
+	return err.Cause
+}
+
+func newCLIError(code ErrorCode, message string, cause error) *CLIError {
+	return &CLIError{Code: code, Message: message, PublicMessage: message, Cause: cause}
+}
+
+type errorDetail struct {
+	Code       ErrorCode `json:"code"`
+	Message    string    `json:"message"`
+	HTTPStatus int       `json:"http_status,omitempty"`
+	Retryable  bool      `json:"retryable"`
+}
+
+type errorEnvelope struct {
+	Error errorDetail `json:"error"`
+}
+
+func WriteErrorJSON(out io.Writer, err error) error {
+	return writeJSON(out, errorEnvelope{Error: errorDetails(err)})
+}
+
+func errorDetails(err error) errorDetail {
+	var cliErr *CLIError
+	if errors.As(err, &cliErr) {
+		message := cliErr.PublicMessage
+		if message == "" {
+			message = cliErr.Message
+		}
+		return errorDetail{
+			Code:       cliErr.Code,
+			Message:    message,
+			HTTPStatus: cliErr.HTTPStatus,
+			Retryable:  cliErr.Retryable,
+		}
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return errorDetail{Code: ErrorTimeout, Message: err.Error(), Retryable: true}
+	}
+	if errors.Is(err, fs.ErrNotExist) {
+		return errorDetail{Code: ErrorNotFound, Message: err.Error(), Retryable: false}
+	}
+	if errors.Is(err, fs.ErrPermission) {
+		return errorDetail{Code: ErrorPermissionDenied, Message: err.Error(), Retryable: false}
+	}
+	var statusErr interface{ HTTPStatusCode() int }
+	if errors.As(err, &statusErr) {
+		statusCode := statusErr.HTTPStatusCode()
+		code, retryable := httpErrorCode(statusCode)
+		return errorDetail{
+			Code:       code,
+			Message:    fmt.Sprintf("request failed: HTTP %d", statusCode),
+			HTTPStatus: statusCode,
+			Retryable:  retryable,
+		}
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) {
+		if netErr.Timeout() {
+			return errorDetail{Code: ErrorTimeout, Message: err.Error(), Retryable: true}
+		}
+		return errorDetail{Code: ErrorConnectionFailed, Message: err.Error(), Retryable: true}
+	}
+	return errorDetail{Code: ErrorCommandFailed, Message: err.Error(), Retryable: false}
+}
+
+func responseStatusError(action string, statusCode int, status string, body []byte) error {
+	detail := strings.TrimSpace(string(body))
+	legacyMessage := fmt.Sprintf("%s failed: %s", action, status)
+	if detail != "" {
+		legacyMessage += ": " + detail
+	}
+
+	return httpStatusCLIError(
+		statusCode,
+		legacyMessage,
+		fmt.Sprintf("%s failed: %s", action, status),
+	)
+}
+
+func httpStatusCLIError(statusCode int, legacyMessage, publicMessage string) error {
+	code, retryable := httpErrorCode(statusCode)
+	return &CLIError{
+		Code:          code,
+		Message:       legacyMessage,
+		PublicMessage: publicMessage,
+		HTTPStatus:    statusCode,
+		Retryable:     retryable,
+	}
+}
+
+func httpErrorCode(statusCode int) (ErrorCode, bool) {
+	switch statusCode {
+	case http.StatusBadRequest, http.StatusUnprocessableEntity:
+		return ErrorInvalidInput, false
+	case http.StatusUnauthorized:
+		return ErrorAuthFailed, false
+	case http.StatusForbidden:
+		return ErrorPermissionDenied, false
+	case http.StatusNotFound:
+		return ErrorNotFound, false
+	case http.StatusRequestTimeout, http.StatusGatewayTimeout:
+		return ErrorTimeout, true
+	case http.StatusConflict:
+		return ErrorConflict, false
+	case http.StatusTooManyRequests:
+		return ErrorRateLimited, true
+	default:
+		if statusCode >= http.StatusInternalServerError {
+			return ErrorServer, true
+		}
+		return ErrorCommandFailed, false
+	}
+}
+
+type renderedError struct {
+	err error
+}
+
+func (err renderedError) Error() string { return err.err.Error() }
+func (err renderedError) Unwrap() error { return err.err }
+
+func MarkErrorRendered(err error) error {
+	if err == nil {
+		return nil
+	}
+	return renderedError{err: err}
+}
+
+func ErrorWasRendered(err error) bool {
+	var rendered renderedError
+	return errors.As(err, &rendered)
+}

--- a/cmd/errors.go
+++ b/cmd/errors.go
@@ -97,6 +97,9 @@ func errorDetails(err error) errorDetail {
 	if errors.Is(err, fs.ErrPermission) {
 		return errorDetail{Code: ErrorPermissionDenied, Message: err.Error(), Retryable: false}
 	}
+	if isCommandInputError(err) {
+		return errorDetail{Code: ErrorInvalidInput, Message: err.Error(), Retryable: false}
+	}
 	var statusErr interface{ HTTPStatusCode() int }
 	if errors.As(err, &statusErr) {
 		statusCode := statusErr.HTTPStatusCode()
@@ -116,6 +119,26 @@ func errorDetails(err error) errorDetail {
 		return errorDetail{Code: ErrorConnectionFailed, Message: err.Error(), Retryable: true}
 	}
 	return errorDetail{Code: ErrorCommandFailed, Message: err.Error(), Retryable: false}
+}
+
+func isCommandInputError(err error) bool {
+	message := err.Error()
+	for _, prefix := range []string{
+		"unknown command ",
+		"unknown flag: ",
+		"flag needs an argument: ",
+		"invalid argument ",
+		"requires at least ",
+		"accepts at most ",
+		"accepts between ",
+		"accepts ",
+		"unsupported output format ",
+	} {
+		if strings.HasPrefix(message, prefix) {
+			return true
+		}
+	}
+	return false
 }
 
 func responseStatusError(action string, statusCode int, status string, body []byte) error {

--- a/cmd/errors.go
+++ b/cmd/errors.go
@@ -59,6 +59,10 @@ func newCLIError(code ErrorCode, message string, cause error) *CLIError {
 	return &CLIError{Code: code, Message: message, PublicMessage: message, Cause: cause}
 }
 
+func newInvalidResponseError(err error) *CLIError {
+	return newCLIError(ErrorInvalidResponse, err.Error(), err)
+}
+
 type errorDetail struct {
 	Code       ErrorCode `json:"code"`
 	Message    string    `json:"message"`

--- a/cmd/errors_test.go
+++ b/cmd/errors_test.go
@@ -1,0 +1,96 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestHTTPErrorCode(t *testing.T) {
+	tests := []struct {
+		status    int
+		code      ErrorCode
+		retryable bool
+	}{
+		{400, ErrorInvalidInput, false},
+		{401, ErrorAuthFailed, false},
+		{403, ErrorPermissionDenied, false},
+		{404, ErrorNotFound, false},
+		{408, ErrorTimeout, true},
+		{409, ErrorConflict, false},
+		{422, ErrorInvalidInput, false},
+		{429, ErrorRateLimited, true},
+		{500, ErrorServer, true},
+	}
+	for _, test := range tests {
+		code, retryable := httpErrorCode(test.status)
+		if code != test.code || retryable != test.retryable {
+			t.Fatalf("status %d: got (%s, %t), want (%s, %t)", test.status, code, retryable, test.code, test.retryable)
+		}
+	}
+}
+
+func TestWriteErrorJSONRedactsHTTPResponseBody(t *testing.T) {
+	err := responseStatusError("list datasets", 403, "403 Forbidden", []byte("secret backend detail"))
+	var output bytes.Buffer
+	if writeErr := WriteErrorJSON(&output, err); writeErr != nil {
+		t.Fatal(writeErr)
+	}
+
+	var result errorEnvelope
+	if jsonErr := json.Unmarshal(output.Bytes(), &result); jsonErr != nil {
+		t.Fatal(jsonErr)
+	}
+	if result.Error.Code != ErrorPermissionDenied || result.Error.HTTPStatus != 403 || result.Error.Retryable {
+		t.Fatalf("unexpected error envelope: %+v", result.Error)
+	}
+	if strings.Contains(result.Error.Message, "secret backend detail") {
+		t.Fatalf("structured error leaked response body: %q", result.Error.Message)
+	}
+	if !strings.Contains(err.Error(), "secret backend detail") {
+		t.Fatalf("text-compatible error no longer contains legacy detail: %q", err)
+	}
+}
+
+func TestWriteErrorJSONFallback(t *testing.T) {
+	var output bytes.Buffer
+	if err := WriteErrorJSON(&output, errors.New("boom")); err != nil {
+		t.Fatal(err)
+	}
+	var result errorEnvelope
+	if err := json.Unmarshal(output.Bytes(), &result); err != nil {
+		t.Fatal(err)
+	}
+	if result.Error.Code != ErrorCommandFailed || result.Error.Message != "boom" || result.Error.Retryable {
+		t.Fatalf("unexpected fallback envelope: %+v", result.Error)
+	}
+}
+
+func TestWriteErrorJSONClassifiesMissingFileAsNotFound(t *testing.T) {
+	missing := &os.PathError{Op: "open", Path: "/missing/config.toml", Err: os.ErrNotExist}
+	var output bytes.Buffer
+	if err := WriteErrorJSON(&output, fmt.Errorf("read config: %w", missing)); err != nil {
+		t.Fatal(err)
+	}
+	var result errorEnvelope
+	if err := json.Unmarshal(output.Bytes(), &result); err != nil {
+		t.Fatal(err)
+	}
+	if result.Error.Code != ErrorNotFound || result.Error.Retryable {
+		t.Fatalf("unexpected missing-file classification: %+v", result.Error)
+	}
+}
+
+func TestRenderedErrorMarker(t *testing.T) {
+	err := MarkErrorRendered(errors.New("already printed"))
+	if !ErrorWasRendered(err) {
+		t.Fatal("expected error to be marked as rendered")
+	}
+	if err.Error() != "already printed" {
+		t.Fatalf("unexpected error text: %q", err)
+	}
+}

--- a/cmd/errors_test.go
+++ b/cmd/errors_test.go
@@ -85,6 +85,34 @@ func TestWriteErrorJSONClassifiesMissingFileAsNotFound(t *testing.T) {
 	}
 }
 
+func TestWriteErrorJSONClassifiesCommandInputErrors(t *testing.T) {
+	for _, message := range []string{
+		`unknown command "wat" for "pb"`,
+		"unknown flag: --wat",
+		"flag needs an argument: --output",
+		`invalid argument "wat" for "--output" flag`,
+		"requires at least 1 arg(s), only received 0",
+		"accepts at most 1 arg(s), received 2",
+		"accepts between 1 and 2 arg(s), received 3",
+		"accepts 1 arg(s), received 0",
+		`unsupported output format "yaml" (expected text or json)`,
+	} {
+		t.Run(message, func(t *testing.T) {
+			var output bytes.Buffer
+			if err := WriteErrorJSON(&output, errors.New(message)); err != nil {
+				t.Fatal(err)
+			}
+			var result errorEnvelope
+			if err := json.Unmarshal(output.Bytes(), &result); err != nil {
+				t.Fatal(err)
+			}
+			if result.Error.Code != ErrorInvalidInput || result.Error.Retryable {
+				t.Fatalf("unexpected command-input classification: %+v", result.Error)
+			}
+		})
+	}
+}
+
 func TestRenderedErrorMarker(t *testing.T) {
 	err := MarkErrorRendered(errors.New("already printed"))
 	if !ErrorWasRendered(err) {

--- a/cmd/exit_status_test.go
+++ b/cmd/exit_status_test.go
@@ -1,0 +1,93 @@
+package cmd
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/parseablehq/pb/pkg/config"
+)
+
+type commandRoundTripFunc func(*http.Request) (*http.Response, error)
+
+func (fn commandRoundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return fn(req)
+}
+
+func useCommandTransport(t *testing.T, fn commandRoundTripFunc) {
+	t.Helper()
+	originalTransport := http.DefaultTransport
+	http.DefaultTransport = fn
+	originalProfile := DefaultProfile
+	DefaultProfile = config.Profile{URL: "https://example.com", APIKey: "test-key"}
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+		DefaultProfile = originalProfile
+	})
+}
+
+func commandHTTPResponse(statusCode int, status, body string) *http.Response {
+	return &http.Response{
+		StatusCode: statusCode,
+		Status:     status,
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+}
+
+func TestAddDatasetReturnsErrorForServerFailure(t *testing.T) {
+	useCommandTransport(t, func(*http.Request) (*http.Response, error) {
+		return commandHTTPResponse(http.StatusInternalServerError, "500 Internal Server Error", "storage unavailable"), nil
+	})
+	if err := AddDatasetCmd.Flags().Set(datasetTypeFlag, "logs"); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = AddDatasetCmd.Flags().Set(datasetTypeFlag, "") })
+
+	err := AddDatasetCmd.RunE(AddDatasetCmd, []string{"backend"})
+	if err == nil || !strings.Contains(err.Error(), "create dataset failed: 500 Internal Server Error") {
+		t.Fatalf("expected server failure, got %v", err)
+	}
+}
+
+func TestRemoveUserReturnsErrorForServerFailure(t *testing.T) {
+	useCommandTransport(t, func(*http.Request) (*http.Response, error) {
+		return commandHTTPResponse(http.StatusForbidden, "403 Forbidden", "denied"), nil
+	})
+
+	err := RemoveUserCmd.RunE(RemoveUserCmd, []string{"alice"})
+	if err == nil || !strings.Contains(err.Error(), "delete user failed: 403 Forbidden") {
+		t.Fatalf("expected server failure, got %v", err)
+	}
+}
+
+func TestRemoveRoleReturnsErrorForServerFailure(t *testing.T) {
+	useCommandTransport(t, func(req *http.Request) (*http.Response, error) {
+		if req.Method == http.MethodGet {
+			return commandHTTPResponse(http.StatusOK, "200 OK", `{"reader":[]}`), nil
+		}
+		return commandHTTPResponse(http.StatusForbidden, "403 Forbidden", "denied"), nil
+	})
+
+	err := RemoveRoleCmd.RunE(RemoveRoleCmd, []string{"reader"})
+	if err == nil || !strings.Contains(err.Error(), "delete role failed: 403 Forbidden") {
+		t.Fatalf("expected server failure, got %v", err)
+	}
+}
+
+func TestRemoveProfileReturnsErrorWhenProfileDoesNotExist(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	if err := config.WriteConfigToFile(&config.Config{
+		Profiles: map[string]config.Profile{
+			"local": {URL: "https://example.com", APIKey: "test-key"},
+		},
+		DefaultProfile: "local",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	err := RemoveProfileCmd.RunE(RemoveProfileCmd, []string{"missing"})
+	if err == nil || !strings.Contains(err.Error(), "no profile found") {
+		t.Fatalf("expected missing profile error, got %v", err)
+	}
+}

--- a/cmd/exit_status_test.go
+++ b/cmd/exit_status_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bytes"
 	"io"
 	"net/http"
 	"strings"
@@ -72,6 +73,138 @@ func TestRemoveRoleReturnsErrorForServerFailure(t *testing.T) {
 	err := RemoveRoleCmd.RunE(RemoveRoleCmd, []string{"reader"})
 	if err == nil || !strings.Contains(err.Error(), "delete role failed: 403 Forbidden") {
 		t.Fatalf("expected server failure, got %v", err)
+	}
+}
+
+func TestRemoveRoleMissingReturnsNotFound(t *testing.T) {
+	useCommandTransport(t, func(*http.Request) (*http.Response, error) {
+		return commandHTTPResponse(http.StatusOK, "200 OK", `{"reader":[]}`), nil
+	})
+
+	err := RemoveRoleCmd.RunE(RemoveRoleCmd, []string{"missing"})
+	if err == nil {
+		t.Fatal("expected missing role error")
+	}
+	if detail := errorDetails(err); detail.Code != ErrorNotFound {
+		t.Fatalf("unexpected missing-role classification: %+v", detail)
+	}
+}
+
+func TestAddUserMissingRoleReturnsNotFound(t *testing.T) {
+	useCommandTransport(t, func(req *http.Request) (*http.Response, error) {
+		if strings.HasSuffix(req.URL.Path, "/user") {
+			return commandHTTPResponse(http.StatusOK, "200 OK", `[]`), nil
+		}
+		return commandHTTPResponse(http.StatusOK, "200 OK", `{"reader":[]}`), nil
+	})
+	role := AddUserCmd.Flags().Lookup(roleFlag)
+	previousRole := role.Value.String()
+	previousRoleChanged := role.Changed
+	t.Cleanup(func() {
+		_ = role.Value.Set(previousRole)
+		role.Changed = previousRoleChanged
+	})
+	if err := AddUserCmd.Flags().Set(roleFlag, "missing"); err != nil {
+		t.Fatal(err)
+	}
+
+	err := AddUserCmd.RunE(AddUserCmd, []string{"alice"})
+	if err == nil {
+		t.Fatal("expected missing role error")
+	}
+	if detail := errorDetails(err); detail.Code != ErrorNotFound {
+		t.Fatalf("unexpected missing-role classification: %+v", detail)
+	}
+}
+
+func TestSetUserRoleMissingUserReturnsNotFound(t *testing.T) {
+	useCommandTransport(t, func(*http.Request) (*http.Response, error) {
+		return commandHTTPResponse(http.StatusOK, "200 OK", `[{"id":"bob","method":"native"}]`), nil
+	})
+
+	err := SetUserRoleCmd.RunE(SetUserRoleCmd, []string{"alice", "reader"})
+	if err == nil {
+		t.Fatal("expected missing user error")
+	}
+	if detail := errorDetails(err); detail.Code != ErrorNotFound {
+		t.Fatalf("unexpected missing-user classification: %+v", detail)
+	}
+}
+
+func TestSetUserRoleMissingRoleReturnsNotFound(t *testing.T) {
+	useCommandTransport(t, func(req *http.Request) (*http.Response, error) {
+		if strings.HasSuffix(req.URL.Path, "/user") {
+			return commandHTTPResponse(http.StatusOK, "200 OK", `[{"id":"alice","method":"native"}]`), nil
+		}
+		return commandHTTPResponse(http.StatusOK, "200 OK", `{"reader":[]}`), nil
+	})
+
+	err := SetUserRoleCmd.RunE(SetUserRoleCmd, []string{"alice", "missing"})
+	if err == nil {
+		t.Fatal("expected missing role error")
+	}
+	if detail := errorDetails(err); detail.Code != ErrorNotFound {
+		t.Fatalf("unexpected missing-role classification: %+v", detail)
+	}
+}
+
+func TestListUserJSONDoesNotWritePartialResult(t *testing.T) {
+	useCommandTransport(t, func(req *http.Request) (*http.Response, error) {
+		if strings.HasSuffix(req.URL.Path, "/user/alice/role") {
+			return commandHTTPResponse(http.StatusInternalServerError, "500 Internal Server Error", "unavailable"), nil
+		}
+		return commandHTTPResponse(http.StatusOK, "200 OK", `[{"id":"alice","method":"native"}]`), nil
+	})
+	output := ListUserCmd.Flags().Lookup("output")
+	previousOutput := output.Value.String()
+	previousOutputChanged := output.Changed
+	var stdout bytes.Buffer
+	ListUserCmd.SetOut(&stdout)
+	t.Cleanup(func() {
+		_ = output.Value.Set(previousOutput)
+		output.Changed = previousOutputChanged
+		ListUserCmd.SetOut(nil)
+	})
+	if err := ListUserCmd.Flags().Set("output", "json"); err != nil {
+		t.Fatal(err)
+	}
+
+	err := ListUserCmd.RunE(ListUserCmd, nil)
+	if err == nil {
+		t.Fatal("expected role enrichment error")
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("partial JSON written before error: %q", stdout.String())
+	}
+}
+
+func TestListRoleJSONDoesNotWritePartialResult(t *testing.T) {
+	useCommandTransport(t, func(req *http.Request) (*http.Response, error) {
+		if strings.HasSuffix(req.URL.Path, "/role/reader") {
+			return commandHTTPResponse(http.StatusInternalServerError, "500 Internal Server Error", "unavailable"), nil
+		}
+		return commandHTTPResponse(http.StatusOK, "200 OK", `{"reader":[]}`), nil
+	})
+	output := ListRoleCmd.Flags().Lookup("output")
+	previousOutput := output.Value.String()
+	previousOutputChanged := output.Changed
+	var stdout bytes.Buffer
+	ListRoleCmd.SetOut(&stdout)
+	t.Cleanup(func() {
+		_ = output.Value.Set(previousOutput)
+		output.Changed = previousOutputChanged
+		ListRoleCmd.SetOut(nil)
+	})
+	if err := ListRoleCmd.Flags().Set("output", "json"); err != nil {
+		t.Fatal(err)
+	}
+
+	err := ListRoleCmd.RunE(ListRoleCmd, nil)
+	if err == nil {
+		t.Fatal("expected role detail error")
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("partial JSON written before error: %q", stdout.String())
 	}
 }
 

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -75,9 +75,11 @@ var GenerateSchemaCmd = &cobra.Command{
 
 		// Check for non-200 status codes
 		if resp.StatusCode != http.StatusOK {
-			body, _ := io.ReadAll(resp.Body)
-			fmt.Printf(common.Red+"Error response: %s\n"+common.Reset, string(body))
-			return fmt.Errorf(common.Red+"non-200 status code received: %s"+common.Reset, resp.Status)
+			body, readErr := io.ReadAll(resp.Body)
+			if readErr != nil {
+				return fmt.Errorf("failed to read schema detection error response: %w", readErr)
+			}
+			return responseStatusError("detect schema", resp.StatusCode, resp.Status, body)
 		}
 
 		// Parse and print the response
@@ -152,9 +154,11 @@ var CreateSchemaCmd = &cobra.Command{
 
 		// Check for non-200 status codes
 		if resp.StatusCode != http.StatusOK {
-			body, _ := io.ReadAll(resp.Body)
-			fmt.Printf(common.Red+"Error response: %s\n"+common.Reset, string(body))
-			return fmt.Errorf(common.Red+"non-200 status code received: %s"+common.Reset, resp.Status)
+			body, readErr := io.ReadAll(resp.Body)
+			if readErr != nil {
+				return fmt.Errorf("failed to read schema creation error response: %w", readErr)
+			}
+			return responseStatusError("create schema", resp.StatusCode, resp.Status, body)
 		}
 
 		// Parse and print the response

--- a/cmd/output.go
+++ b/cmd/output.go
@@ -1,0 +1,70 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+const (
+	outputText = "text"
+	outputJSON = "json"
+)
+
+func commandOutputFormat(cmd *cobra.Command) (string, error) {
+	value, err := cmd.Flags().GetString("output")
+	if err != nil {
+		return "", err
+	}
+	return validateOutputFormat(value)
+}
+
+func validateOutputFormat(value string) (string, error) {
+	format := strings.ToLower(strings.TrimSpace(value))
+	if format == "" {
+		format = outputText
+	}
+	if format != outputText && format != outputJSON {
+		message := fmt.Sprintf("unsupported output format %q (expected text or json)", value)
+		return "", newCLIError(ErrorInvalidInput, message, nil)
+	}
+	return format, nil
+}
+
+func writeJSON(out io.Writer, value interface{}) error {
+	encoder := json.NewEncoder(out)
+	encoder.SetIndent("", "  ")
+	encoder.SetEscapeHTML(false)
+	if err := encoder.Encode(value); err != nil {
+		return fmt.Errorf("failed to encode JSON output: %w", err)
+	}
+	return nil
+}
+
+func writeRawJSON(out io.Writer, body []byte) error {
+	decoder := json.NewDecoder(bytes.NewReader(body))
+	decoder.UseNumber()
+	var value interface{}
+	if err := decoder.Decode(&value); err != nil {
+		return fmt.Errorf("server returned invalid JSON: %w", err)
+	}
+	var trailing interface{}
+	if err := decoder.Decode(&trailing); err != io.EOF {
+		if err == nil {
+			return fmt.Errorf("server returned multiple JSON values")
+		}
+		return fmt.Errorf("server returned invalid JSON: %w", err)
+	}
+	return writeJSON(out, value)
+}
+
+func nonNilSlice[T any](items []T) []T {
+	if items == nil {
+		return []T{}
+	}
+	return items
+}

--- a/cmd/output.go
+++ b/cmd/output.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -50,14 +51,14 @@ func writeRawJSON(out io.Writer, body []byte) error {
 	decoder.UseNumber()
 	var value interface{}
 	if err := decoder.Decode(&value); err != nil {
-		return fmt.Errorf("server returned invalid JSON: %w", err)
+		return newInvalidResponseError(fmt.Errorf("server returned invalid JSON: %w", err))
 	}
 	var trailing interface{}
 	if err := decoder.Decode(&trailing); err != io.EOF {
 		if err == nil {
-			return fmt.Errorf("server returned multiple JSON values")
+			return newInvalidResponseError(errors.New("server returned multiple JSON values"))
 		}
-		return fmt.Errorf("server returned invalid JSON: %w", err)
+		return newInvalidResponseError(fmt.Errorf("server returned invalid JSON: %w", err))
 	}
 	return writeJSON(out, value)
 }

--- a/cmd/output_test.go
+++ b/cmd/output_test.go
@@ -1,0 +1,68 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestValidateOutputFormat(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{input: "", want: outputText},
+		{input: "text", want: outputText},
+		{input: " JSON ", want: outputJSON},
+	}
+	for _, test := range tests {
+		got, err := validateOutputFormat(test.input)
+		if err != nil {
+			t.Fatalf("validateOutputFormat(%q): %v", test.input, err)
+		}
+		if got != test.want {
+			t.Fatalf("validateOutputFormat(%q)=%q want=%q", test.input, got, test.want)
+		}
+	}
+	if _, err := validateOutputFormat("yaml"); err == nil {
+		t.Fatal("expected unsupported output format error")
+	}
+}
+
+func TestWriteRawJSONProducesOneValidJSONDocument(t *testing.T) {
+	var output bytes.Buffer
+	if err := writeRawJSON(&output, []byte(`{"message":"ok","count":2}`)); err != nil {
+		t.Fatal(err)
+	}
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(output.Bytes(), &decoded); err != nil {
+		t.Fatalf("invalid JSON output %q: %v", output.String(), err)
+	}
+	if strings.Count(output.String(), "\n") < 2 {
+		t.Fatalf("expected formatted JSON, got %q", output.String())
+	}
+}
+
+func TestWriteRawJSONRejectsMalformedOrMultipleDocuments(t *testing.T) {
+	for _, body := range []string{`not-json`, `{} {}`} {
+		var output bytes.Buffer
+		if err := writeRawJSON(&output, []byte(body)); err == nil {
+			t.Fatalf("expected error for %q", body)
+		}
+		if output.Len() != 0 {
+			t.Fatalf("unexpected partial output for %q: %q", body, output.String())
+		}
+	}
+}
+
+func TestNonNilSliceEncodesEmptyArray(t *testing.T) {
+	var values []string
+	var output bytes.Buffer
+	if err := writeJSON(&output, nonNilSlice(values)); err != nil {
+		t.Fatal(err)
+	}
+	if output.String() != "[]\n" {
+		t.Fatalf("nil slice encoded as %q, want empty JSON array", output.String())
+	}
+}

--- a/cmd/output_test.go
+++ b/cmd/output_test.go
@@ -47,8 +47,12 @@ func TestWriteRawJSONProducesOneValidJSONDocument(t *testing.T) {
 func TestWriteRawJSONRejectsMalformedOrMultipleDocuments(t *testing.T) {
 	for _, body := range []string{`not-json`, `{} {}`} {
 		var output bytes.Buffer
-		if err := writeRawJSON(&output, []byte(body)); err == nil {
+		err := writeRawJSON(&output, []byte(body))
+		if err == nil {
 			t.Fatalf("expected error for %q", body)
+		}
+		if detail := errorDetails(err); detail.Code != ErrorInvalidResponse || detail.Retryable {
+			t.Fatalf("unexpected malformed-response classification for %q: %+v", body, detail)
 		}
 		if output.Len() != 0 {
 			t.Fatalf("unexpected partial output for %q: %q", body, output.String())

--- a/cmd/pre.go
+++ b/cmd/pre.go
@@ -17,7 +17,6 @@
 package cmd
 
 import (
-	"errors"
 	"os"
 
 	"github.com/parseablehq/pb/pkg/config"
@@ -35,13 +34,13 @@ func PreRunDefaultProfile(_ *cobra.Command, _ []string) error {
 func PreRun() error {
 	conf, err := config.ReadConfigFromFile()
 	if os.IsNotExist(err) {
-		return errors.New("no profile configured. run: pb login")
+		return newCLIError(ErrorNotFound, "no profile configured. run: pb login", nil)
 	} else if err != nil {
 		return err
 	}
 
 	if conf.Profiles == nil || conf.DefaultProfile == "" {
-		return errors.New("no profile configured. run: pb login")
+		return newCLIError(ErrorNotFound, "no profile configured. run: pb login", nil)
 	}
 
 	DefaultProfile = conf.Profiles[conf.DefaultProfile]

--- a/cmd/pre.go
+++ b/cmd/pre.go
@@ -43,6 +43,10 @@ func PreRun() error {
 		return newCLIError(ErrorNotFound, "no profile configured. run: pb login", nil)
 	}
 
-	DefaultProfile = conf.Profiles[conf.DefaultProfile]
+	profile, ok := conf.Profiles[conf.DefaultProfile]
+	if !ok {
+		return newCLIError(ErrorNotFound, "no profile configured. run: pb login", nil)
+	}
+	DefaultProfile = profile
 	return nil
 }

--- a/cmd/pre_test.go
+++ b/cmd/pre_test.go
@@ -1,0 +1,27 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/parseablehq/pb/pkg/config"
+)
+
+func TestPreRunRejectsMissingDefaultProfileEntry(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	if err := config.WriteConfigToFile(&config.Config{
+		Profiles: map[string]config.Profile{
+			"available": {URL: "https://example.com"},
+		},
+		DefaultProfile: "missing",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	err := PreRun()
+	if err == nil {
+		t.Fatal("expected missing default profile error")
+	}
+	if detail := errorDetails(err); detail.Code != ErrorNotFound || detail.Retryable {
+		t.Fatalf("unexpected missing-profile classification: %+v", detail)
+	}
+}

--- a/cmd/profile.go
+++ b/cmd/profile.go
@@ -17,7 +17,6 @@ package cmd
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/url"
 	"strings"
@@ -124,7 +123,7 @@ var AddProfileCmd = &cobra.Command{
 			return err
 		}
 		if strings.TrimSpace(profileAPIKey) != "" && len(args) != 2 {
-			return errors.New("--api-key cannot be combined with username/password")
+			return newCLIError(ErrorInvalidInput, "--api-key cannot be combined with username/password", nil)
 		}
 		return cobra.MaximumNArgs(4)(cmd, args)
 	},
@@ -219,10 +218,9 @@ var RemoveProfileCmd = &cobra.Command{
 
 		_, exists := fileConfig.Profiles[name]
 		if !exists {
-			msg := fmt.Sprintf("No profile found with the name: %s", name)
-			cmd.Annotations["error"] = msg
-			fmt.Println(msg)
-			return nil
+			commandErr := newCLIError(ErrorNotFound, fmt.Sprintf("no profile found with the name: %s", name), nil)
+			cmd.Annotations["error"] = commandErr.Error()
+			return commandErr
 		}
 
 		wasDefault := fileConfig.DefaultProfile == name
@@ -306,7 +304,7 @@ var DefaultProfileCmd = &cobra.Command{
 		if !exists {
 			commandError := fmt.Sprintf("profile %s does not exist", name)
 			cmd.Annotations["error"] = commandError
-			return errors.New(commandError)
+			return newCLIError(ErrorNotFound, commandError, nil)
 		}
 
 		fileConfig.DefaultProfile = name
@@ -382,6 +380,10 @@ var ListProfileCmd = &cobra.Command{
 			cmd.Annotations = make(map[string]string)
 		}
 		startTime := time.Now()
+		format, err := validateOutputFormat(outputFormat)
+		if err != nil {
+			return err
+		}
 
 		fileConfig, err := config.ReadConfigFromFile()
 		if err != nil {
@@ -389,8 +391,8 @@ var ListProfileCmd = &cobra.Command{
 			return err
 		}
 
-		if outputFormat == "json" {
-			commandError := outputResult(safeProfilesOutput(fileConfig.Profiles))
+		if format == outputJSON {
+			commandError := writeJSON(cmd.OutOrStdout(), safeProfilesOutput(fileConfig.Profiles))
 			cmd.Annotations["executionTime"] = time.Since(startTime).String()
 			if commandError != nil {
 				cmd.Annotations["error"] = commandError.Error()

--- a/cmd/promql.go
+++ b/cmd/promql.go
@@ -350,7 +350,7 @@ func runPromqlQuery(cmd *cobra.Command, args []string) error {
 
 	var result promqlResponse
 	if err := json.Unmarshal(body, &result); err != nil {
-		return fmt.Errorf("failed to decode PromQL response: %w", err)
+		return newInvalidResponseError(fmt.Errorf("failed to decode PromQL response: %w", err))
 	}
 	if result.Status == "error" {
 		return fmt.Errorf("query error (%s): %s", result.ErrorType, result.Error)
@@ -426,7 +426,7 @@ var promqlLabelsCmd = &cobra.Command{
 			Error  string   `json:"error,omitempty"`
 		}
 		if err := json.Unmarshal(body, &resp); err != nil {
-			return fmt.Errorf("failed to decode PromQL labels response: %w", err)
+			return newInvalidResponseError(fmt.Errorf("failed to decode PromQL labels response: %w", err))
 		}
 		if resp.Status == "error" {
 			return fmt.Errorf("%s", resp.Error)
@@ -482,7 +482,7 @@ var promqlLabelValuesCmd = &cobra.Command{
 			Error  string   `json:"error,omitempty"`
 		}
 		if err := json.Unmarshal(body, &resp); err != nil {
-			return fmt.Errorf("failed to decode PromQL label-values response: %w", err)
+			return newInvalidResponseError(fmt.Errorf("failed to decode PromQL label-values response: %w", err))
 		}
 		if resp.Status == "error" {
 			return fmt.Errorf("%s", resp.Error)
@@ -546,7 +546,7 @@ var promqlSeriesCmd = &cobra.Command{
 			Error  string              `json:"error,omitempty"`
 		}
 		if err := json.Unmarshal(body, &resp); err != nil {
-			return fmt.Errorf("failed to decode PromQL series response: %w", err)
+			return newInvalidResponseError(fmt.Errorf("failed to decode PromQL series response: %w", err))
 		}
 		if resp.Status == "error" {
 			return fmt.Errorf("%s", resp.Error)
@@ -620,7 +620,7 @@ var promqlCardinalityLabelNamesCmd = &cobra.Command{
 			Error  string             `json:"error,omitempty"`
 		}
 		if err := json.Unmarshal(body, &resp); err != nil {
-			return fmt.Errorf("failed to decode PromQL cardinality response: %w", err)
+			return newInvalidResponseError(fmt.Errorf("failed to decode PromQL cardinality response: %w", err))
 		}
 		if resp.Status == "error" {
 			return fmt.Errorf("%s", resp.Error)
@@ -675,7 +675,7 @@ var promqlCardinalityLabelValuesCmd = &cobra.Command{
 			Error  string             `json:"error,omitempty"`
 		}
 		if err := json.Unmarshal(body, &resp); err != nil {
-			return fmt.Errorf("failed to decode PromQL cardinality response: %w", err)
+			return newInvalidResponseError(fmt.Errorf("failed to decode PromQL cardinality response: %w", err))
 		}
 		if resp.Status == "error" {
 			return fmt.Errorf("%s", resp.Error)
@@ -776,7 +776,7 @@ var promqlCardinalityActiveSeriesCmd = &cobra.Command{
 			Error string `json:"error,omitempty"`
 		}
 		if err := json.Unmarshal(body, &resp); err != nil {
-			return fmt.Errorf("failed to decode PromQL active-series response: %w", err)
+			return newInvalidResponseError(fmt.Errorf("failed to decode PromQL active-series response: %w", err))
 		}
 		if resp.Status == "error" {
 			return fmt.Errorf("%s", resp.Error)
@@ -831,7 +831,7 @@ var promqlActiveQueriesCmd = &cobra.Command{
 			Error string `json:"error,omitempty"`
 		}
 		if err := json.Unmarshal(body, &resp); err != nil {
-			return fmt.Errorf("failed to decode PromQL active-queries response: %w", err)
+			return newInvalidResponseError(fmt.Errorf("failed to decode PromQL active-queries response: %w", err))
 		}
 		if resp.Status == "error" {
 			return fmt.Errorf("%s", resp.Error)
@@ -900,7 +900,7 @@ var promqlTSDBCmd = &cobra.Command{
 			Error  string          `json:"error,omitempty"`
 		}
 		if err := json.Unmarshal(body, &envelope); err != nil {
-			return fmt.Errorf("failed to decode PromQL TSDB response: %w", err)
+			return newInvalidResponseError(fmt.Errorf("failed to decode PromQL TSDB response: %w", err))
 		}
 		if envelope.Status == "error" {
 			return fmt.Errorf("%s", envelope.Error)
@@ -919,7 +919,7 @@ var promqlTSDBCmd = &cobra.Command{
 			LabelValueCount      []cardinalityEntry `json:"labelValueCountByLabelName"`
 		}
 		if err := json.Unmarshal(envelope.Data, &data); err != nil {
-			return fmt.Errorf("failed to decode PromQL TSDB data: %w", err)
+			return newInvalidResponseError(fmt.Errorf("failed to decode PromQL TSDB data: %w", err))
 		}
 
 		d := data

--- a/cmd/promql.go
+++ b/cmd/promql.go
@@ -212,17 +212,29 @@ func promqlGet(path string, params url.Values) ([]byte, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
-	return io.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return nil, responseStatusError("PromQL request", resp.StatusCode, resp.Status, body)
+	}
+	var envelope struct {
+		Status    string `json:"status"`
+		Error     string `json:"error,omitempty"`
+		ErrorType string `json:"errorType,omitempty"`
+	}
+	if json.Unmarshal(body, &envelope) == nil && envelope.Status == "error" {
+		if envelope.ErrorType != "" {
+			return nil, fmt.Errorf("PromQL error (%s): %s", envelope.ErrorType, envelope.Error)
+		}
+		return nil, fmt.Errorf("PromQL error: %s", envelope.Error)
+	}
+	return body, nil
 }
 
-func printRawJSON(body []byte) {
-	var v interface{}
-	if json.Unmarshal(body, &v) == nil {
-		b, _ := json.MarshalIndent(v, "", "  ")
-		fmt.Println(string(b))
-	} else {
-		fmt.Println(string(body))
-	}
+func printRawJSON(cmd *cobra.Command, body []byte) error {
+	return writeRawJSON(cmd.OutOrStdout(), body)
 }
 
 func optionalTimeParam(params url.Values, cmd *cobra.Command, flagName, paramName string) {
@@ -279,7 +291,10 @@ func runPromqlQuery(cmd *cobra.Command, args []string) error {
 	fromStr, _ := cmd.Flags().GetString("from")
 	toStr, _ := cmd.Flags().GetString("to")
 	step, _ := cmd.Flags().GetString("step")
-	outputFmt, _ := cmd.Flags().GetString("output")
+	outputFmt, err := commandOutputFormat(cmd)
+	if err != nil {
+		return err
+	}
 	instant, _ := cmd.Flags().GetBool("instant")
 	interactive, _ := cmd.Flags().GetBool("interactive")
 	fromStr = promqlInteractiveFromDefault(fromStr, interactive, cmd.Flags().Changed("from"))
@@ -301,9 +316,8 @@ func runPromqlQuery(cmd *cobra.Command, args []string) error {
 	}
 
 	if strings.TrimSpace(expr) == "" {
-		fmt.Println("Please enter a PromQL expression")
-		fmt.Printf("Example:\n  pb promql run \"http_requests_total\" --dataset otel_metrics\n  pb promql run -i\n")
-		return nil
+		message := "PromQL expression is required; example: pb promql run \"http_requests_total\" --dataset otel_metrics"
+		return newCLIError(ErrorInvalidInput, message, nil)
 	}
 
 	params := url.Values{}
@@ -331,14 +345,12 @@ func runPromqlQuery(cmd *cobra.Command, args []string) error {
 	}
 
 	if outputFmt == "json" {
-		printRawJSON(body)
-		return nil
+		return printRawJSON(cmd, body)
 	}
 
 	var result promqlResponse
 	if err := json.Unmarshal(body, &result); err != nil {
-		fmt.Println(string(body))
-		return nil
+		return fmt.Errorf("failed to decode PromQL response: %w", err)
 	}
 	if result.Status == "error" {
 		return fmt.Errorf("query error (%s): %s", result.ErrorType, result.Error)
@@ -390,7 +402,10 @@ var promqlLabelsCmd = &cobra.Command{
 		if len(args) > 0 {
 			stream = args[0]
 		}
-		outputFmt, _ := cmd.Flags().GetString("output")
+		outputFmt, err := commandOutputFormat(cmd)
+		if err != nil {
+			return err
+		}
 
 		params := url.Values{}
 		params.Set("stream", stream)
@@ -402,8 +417,7 @@ var promqlLabelsCmd = &cobra.Command{
 			return err
 		}
 		if outputFmt == "json" {
-			printRawJSON(body)
-			return nil
+			return printRawJSON(cmd, body)
 		}
 
 		var resp struct {
@@ -412,8 +426,7 @@ var promqlLabelsCmd = &cobra.Command{
 			Error  string   `json:"error,omitempty"`
 		}
 		if err := json.Unmarshal(body, &resp); err != nil {
-			fmt.Println(string(body))
-			return nil
+			return fmt.Errorf("failed to decode PromQL labels response: %w", err)
 		}
 		if resp.Status == "error" {
 			return fmt.Errorf("%s", resp.Error)
@@ -445,7 +458,10 @@ var promqlLabelValuesCmd = &cobra.Command{
 		if len(args) > 1 {
 			stream = args[1]
 		}
-		outputFmt, _ := cmd.Flags().GetString("output")
+		outputFmt, err := commandOutputFormat(cmd)
+		if err != nil {
+			return err
+		}
 
 		params := url.Values{}
 		params.Set("stream", stream)
@@ -457,8 +473,7 @@ var promqlLabelValuesCmd = &cobra.Command{
 			return err
 		}
 		if outputFmt == "json" {
-			printRawJSON(body)
-			return nil
+			return printRawJSON(cmd, body)
 		}
 
 		var resp struct {
@@ -467,8 +482,7 @@ var promqlLabelValuesCmd = &cobra.Command{
 			Error  string   `json:"error,omitempty"`
 		}
 		if err := json.Unmarshal(body, &resp); err != nil {
-			fmt.Println(string(body))
-			return nil
+			return fmt.Errorf("failed to decode PromQL label-values response: %w", err)
 		}
 		if resp.Status == "error" {
 			return fmt.Errorf("%s", resp.Error)
@@ -501,10 +515,13 @@ var promqlSeriesCmd = &cobra.Command{
 			stream = args[0]
 		}
 		matchers, _ := cmd.Flags().GetStringArray("match")
-		outputFmt, _ := cmd.Flags().GetString("output")
+		outputFmt, err := commandOutputFormat(cmd)
+		if err != nil {
+			return err
+		}
 
 		if len(matchers) == 0 {
-			return fmt.Errorf("at least one --match selector is required")
+			return newCLIError(ErrorInvalidInput, "at least one --match selector is required", nil)
 		}
 
 		params := url.Values{}
@@ -520,8 +537,7 @@ var promqlSeriesCmd = &cobra.Command{
 			return err
 		}
 		if outputFmt == "json" {
-			printRawJSON(body)
-			return nil
+			return printRawJSON(cmd, body)
 		}
 
 		var resp struct {
@@ -530,8 +546,7 @@ var promqlSeriesCmd = &cobra.Command{
 			Error  string              `json:"error,omitempty"`
 		}
 		if err := json.Unmarshal(body, &resp); err != nil {
-			fmt.Println(string(body))
-			return nil
+			return fmt.Errorf("failed to decode PromQL series response: %w", err)
 		}
 		if resp.Status == "error" {
 			return fmt.Errorf("%s", resp.Error)
@@ -578,7 +593,10 @@ var promqlCardinalityLabelNamesCmd = &cobra.Command{
 		lookback, _ := cmd.Flags().GetInt("lookback")
 		limit, _ := cmd.Flags().GetInt("limit")
 		selector, _ := cmd.Flags().GetString("selector")
-		outputFmt, _ := cmd.Flags().GetString("output")
+		outputFmt, err := commandOutputFormat(cmd)
+		if err != nil {
+			return err
+		}
 
 		params := url.Values{}
 		params.Set("stream", stream)
@@ -593,8 +611,7 @@ var promqlCardinalityLabelNamesCmd = &cobra.Command{
 			return err
 		}
 		if outputFmt == "json" {
-			printRawJSON(body)
-			return nil
+			return printRawJSON(cmd, body)
 		}
 
 		var resp struct {
@@ -603,8 +620,7 @@ var promqlCardinalityLabelNamesCmd = &cobra.Command{
 			Error  string             `json:"error,omitempty"`
 		}
 		if err := json.Unmarshal(body, &resp); err != nil {
-			fmt.Println(string(body))
-			return nil
+			return fmt.Errorf("failed to decode PromQL cardinality response: %w", err)
 		}
 		if resp.Status == "error" {
 			return fmt.Errorf("%s", resp.Error)
@@ -632,7 +648,10 @@ var promqlCardinalityLabelValuesCmd = &cobra.Command{
 		}
 		lookback, _ := cmd.Flags().GetInt("lookback")
 		limit, _ := cmd.Flags().GetInt("limit")
-		outputFmt, _ := cmd.Flags().GetString("output")
+		outputFmt, err := commandOutputFormat(cmd)
+		if err != nil {
+			return err
+		}
 
 		params := url.Values{}
 		params.Set("stream", stream)
@@ -647,8 +666,7 @@ var promqlCardinalityLabelValuesCmd = &cobra.Command{
 			return err
 		}
 		if outputFmt == "json" {
-			printRawJSON(body)
-			return nil
+			return printRawJSON(cmd, body)
 		}
 
 		var resp struct {
@@ -657,8 +675,7 @@ var promqlCardinalityLabelValuesCmd = &cobra.Command{
 			Error  string             `json:"error,omitempty"`
 		}
 		if err := json.Unmarshal(body, &resp); err != nil {
-			fmt.Println(string(body))
-			return nil
+			return fmt.Errorf("failed to decode PromQL cardinality response: %w", err)
 		}
 		if resp.Status == "error" {
 			return fmt.Errorf("%s", resp.Error)
@@ -729,7 +746,10 @@ var promqlCardinalityActiveSeriesCmd = &cobra.Command{
 		if len(args) > 1 {
 			selector = args[1]
 		}
-		outputFmt, _ := cmd.Flags().GetString("output")
+		outputFmt, err := commandOutputFormat(cmd)
+		if err != nil {
+			return err
+		}
 
 		params := url.Values{}
 		params.Set("stream", stream)
@@ -744,8 +764,7 @@ var promqlCardinalityActiveSeriesCmd = &cobra.Command{
 			return err
 		}
 		if outputFmt == "json" {
-			printRawJSON(body)
-			return nil
+			return printRawJSON(cmd, body)
 		}
 
 		var resp struct {
@@ -757,8 +776,7 @@ var promqlCardinalityActiveSeriesCmd = &cobra.Command{
 			Error string `json:"error,omitempty"`
 		}
 		if err := json.Unmarshal(body, &resp); err != nil {
-			fmt.Println(string(body))
-			return nil
+			return fmt.Errorf("failed to decode PromQL active-series response: %w", err)
 		}
 		if resp.Status == "error" {
 			return fmt.Errorf("%s", resp.Error)
@@ -789,15 +807,17 @@ var promqlActiveQueriesCmd = &cobra.Command{
 	Args:    cobra.NoArgs,
 	PreRunE: PreRunDefaultProfile,
 	RunE: func(cmd *cobra.Command, _ []string) error {
-		outputFmt, _ := cmd.Flags().GetString("output")
+		outputFmt, err := commandOutputFormat(cmd)
+		if err != nil {
+			return err
+		}
 
 		body, err := promqlGet("prometheus/api/v1/status/active_queries", nil)
 		if err != nil {
 			return err
 		}
 		if outputFmt == "json" {
-			printRawJSON(body)
-			return nil
+			return printRawJSON(cmd, body)
 		}
 
 		var resp struct {
@@ -811,8 +831,7 @@ var promqlActiveQueriesCmd = &cobra.Command{
 			Error string `json:"error,omitempty"`
 		}
 		if err := json.Unmarshal(body, &resp); err != nil {
-			printRawJSON(body)
-			return nil
+			return fmt.Errorf("failed to decode PromQL active-queries response: %w", err)
 		}
 		if resp.Status == "error" {
 			return fmt.Errorf("%s", resp.Error)
@@ -852,7 +871,10 @@ var promqlTSDBCmd = &cobra.Command{
 		topN, _ := cmd.Flags().GetInt("top")
 		date, _ := cmd.Flags().GetString("date")
 		focusLabel, _ := cmd.Flags().GetString("focus-label")
-		outputFmt, _ := cmd.Flags().GetString("output")
+		outputFmt, err := commandOutputFormat(cmd)
+		if err != nil {
+			return err
+		}
 
 		params := url.Values{}
 		params.Set("stream", stream)
@@ -869,8 +891,7 @@ var promqlTSDBCmd = &cobra.Command{
 			return err
 		}
 		if outputFmt == "json" {
-			printRawJSON(body)
-			return nil
+			return printRawJSON(cmd, body)
 		}
 
 		var envelope struct {
@@ -879,8 +900,7 @@ var promqlTSDBCmd = &cobra.Command{
 			Error  string          `json:"error,omitempty"`
 		}
 		if err := json.Unmarshal(body, &envelope); err != nil {
-			fmt.Println(string(body))
-			return nil
+			return fmt.Errorf("failed to decode PromQL TSDB response: %w", err)
 		}
 		if envelope.Status == "error" {
 			return fmt.Errorf("%s", envelope.Error)
@@ -899,8 +919,7 @@ var promqlTSDBCmd = &cobra.Command{
 			LabelValueCount      []cardinalityEntry `json:"labelValueCountByLabelName"`
 		}
 		if err := json.Unmarshal(envelope.Data, &data); err != nil {
-			fmt.Println(string(body))
-			return nil
+			return fmt.Errorf("failed to decode PromQL TSDB data: %w", err)
 		}
 
 		d := data

--- a/cmd/promql_test.go
+++ b/cmd/promql_test.go
@@ -1,10 +1,12 @@
 package cmd
 
 import (
+	"bytes"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"testing"
 
 	"github.com/parseablehq/pb/pkg/config"
@@ -15,6 +17,34 @@ func TestPromqlInteractiveFromDefaultUsesTenMinutes(t *testing.T) {
 	got := promqlInteractiveFromDefault("5m", true, false)
 	if got != "10m" {
 		t.Fatalf("got %q, want 10m", got)
+	}
+}
+
+func TestPromqlJSONReturnsErrorForServerFailure(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		fmt.Fprint(w, `{"status":"error","errorType":"bad_data","error":"invalid selector"}`)
+	}))
+	defer server.Close()
+
+	originalProfile := DefaultProfile
+	DefaultProfile = config.Profile{URL: server.URL, APIKey: "test-key"}
+	t.Cleanup(func() { DefaultProfile = originalProfile })
+	if err := promqlLabelsCmd.Flags().Set("output", "json"); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = promqlLabelsCmd.Flags().Set("output", "text") })
+	var stdout bytes.Buffer
+	promqlLabelsCmd.SetOut(&stdout)
+	t.Cleanup(func() { promqlLabelsCmd.SetOut(nil) })
+
+	err := promqlLabelsCmd.RunE(promqlLabelsCmd, nil)
+	if err == nil || !strings.Contains(err.Error(), "422 Unprocessable Entity") {
+		t.Fatalf("expected PromQL server error, got %v", err)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("unexpected JSON output on failure: %q", stdout.String())
 	}
 }
 

--- a/cmd/query.go
+++ b/cmd/query.go
@@ -76,9 +76,8 @@ var query = &cobra.Command{
 		}
 
 		if (len(args) == 0 || strings.TrimSpace(args[0]) == "") && !interactive {
-			fmt.Println("Please enter your query")
-			fmt.Printf("Example:\n  pb sql run \"select * from frontend\" --from=10m --to=now\n")
-			return nil
+			message := "SQL query is required; example: pb sql run \"select * from frontend\" --from=10m --to=now"
+			return newCLIError(ErrorInvalidInput, message, nil)
 		}
 
 		var sqlQuery string
@@ -128,7 +127,7 @@ var query = &cobra.Command{
 			return err
 		}
 
-		outputFmt, err := command.Flags().GetString("output")
+		outputFmt, err := commandOutputFormat(command)
 		if err != nil {
 			command.Annotations["error"] = err.Error()
 			return fmt.Errorf("failed to get 'output' flag: %w", err)
@@ -488,9 +487,8 @@ var SaveSQLCmd = &cobra.Command{
 
 		sqlQuery := strings.TrimSpace(args[0])
 		if sqlQuery == "" {
-			fmt.Println("Please enter your query")
-			fmt.Printf("Example:\n  pb sql save \"select * from frontend\"\n")
-			return nil
+			message := "SQL query is required; example: pb sql save \"select * from frontend\""
+			return newCLIError(ErrorInvalidInput, message, nil)
 		}
 
 		start, err := command.Flags().GetString(startFlag)
@@ -732,9 +730,11 @@ func fetchData(client *internalHTTP.HTTPClient, query string, startTime, endTime
 			return fmt.Errorf("failed to read error response body: %w", err)
 		}
 		if preview == "" {
-			return fmt.Errorf("query failed: server returned %s with an empty response body", resp.Status)
+			message := fmt.Sprintf("query failed: server returned %s with an empty response body", resp.Status)
+			return httpStatusCLIError(resp.StatusCode, message, fmt.Sprintf("query failed: server returned %s", resp.Status))
 		}
-		return fmt.Errorf("query failed: server returned %s: %s", resp.Status, preview)
+		legacyMessage := fmt.Sprintf("query failed: server returned %s: %s", resp.Status, preview)
+		return httpStatusCLIError(resp.StatusCode, legacyMessage, fmt.Sprintf("query failed: server returned %s", resp.Status))
 	}
 
 	reader := bufio.NewReader(resp.Body)
@@ -996,7 +996,8 @@ func saveFilter(client *internalHTTP.HTTPClient, sqlQuery, name, startTime, endT
 
 	if resp.StatusCode != 200 {
 		b, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("server returned %s: %s", resp.Status, strings.TrimSpace(string(b)))
+		legacyMessage := fmt.Sprintf("server returned %s: %s", resp.Status, strings.TrimSpace(string(b)))
+		return httpStatusCLIError(resp.StatusCode, legacyMessage, fmt.Sprintf("server returned %s", resp.Status))
 	}
 	return nil
 }

--- a/cmd/queryList.go
+++ b/cmd/queryList.go
@@ -19,9 +19,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net/http"
+	"os"
 	"strings"
 
-	"github.com/parseablehq/pb/pkg/config"
 	internalHTTP "github.com/parseablehq/pb/pkg/http"
 	"github.com/parseablehq/pb/pkg/model"
 	"github.com/spf13/cobra"
@@ -35,64 +36,45 @@ var SavedQueryList = &cobra.Command{
 	Long:         "\nShow the list of saved queries for active user",
 	SilenceUsage: true,
 	PreRunE:      PreRunDefaultProfile,
-	RunE: func(_ *cobra.Command, _ []string) error {
+	RunE: func(cmd *cobra.Command, _ []string) error {
 		client := internalHTTP.DefaultClient(&DefaultProfile)
 
 		// Check if the output flag is set
 		if outputFlag != "" {
-			// Display all filters if output flag is set
-			userConfig, err := config.ReadConfigFromFile()
+			format, err := validateOutputFormat(outputFlag)
 			if err != nil {
-				fmt.Println("Error reading Default Profile")
+				return err
 			}
-			var userProfile config.Profile
-			if profile, ok := userConfig.Profiles[userConfig.DefaultProfile]; ok {
-				userProfile = profile
+			userSavedQueries, err := fetchFilters(&client)
+			if err != nil {
+				return err
 			}
 
-			client := internalHTTP.DefaultClient(&userProfile)
-			userSavedQueries := fetchFilters(&client)
-			// Collect all filter titles in a slice and join with commas
-			var filterDetails []string
-
-			if outputFlag == "json" {
-				// If JSON output is requested, marshal the saved queries to JSON
-				jsonOutput, err := json.MarshalIndent(userSavedQueries, "", "  ")
-				if err != nil {
-					fmt.Println("Error converting saved queries to JSON:", err)
-					return err
-				}
-				if string(jsonOutput) == "null" {
-					fmt.Println("[]")
-					return nil
-				}
-				fmt.Println(string(jsonOutput))
-			} else {
-				for _, query := range userSavedQueries {
-					// Build the line conditionally
-					var parts []string
-					if query.Title != "" {
-						parts = append(parts, query.Title)
-					}
-					if query.Stream != "" {
-						parts = append(parts, query.Stream)
-					}
-					if query.Desc != "" {
-						parts = append(parts, query.Desc)
-					}
-					if query.From != "" {
-						parts = append(parts, query.From)
-					}
-					if query.To != "" {
-						parts = append(parts, query.To)
-					}
-
-					// Join parts with commas and print each query on a new line
-					fmt.Println(strings.Join(parts, ", "))
-				}
+			if format == outputJSON {
+				return writeJSON(cmd.OutOrStdout(), userSavedQueries)
 			}
-			// Print all titles as a single line, comma-separated
-			fmt.Println(strings.Join(filterDetails, " "))
+			for _, query := range userSavedQueries {
+				// Build the line conditionally
+				var parts []string
+				if query.Title != "" {
+					parts = append(parts, query.Title)
+				}
+				if query.Stream != "" {
+					parts = append(parts, query.Stream)
+				}
+				if query.Desc != "" {
+					parts = append(parts, query.Desc)
+				}
+				if query.From != "" {
+					parts = append(parts, query.From)
+				}
+				if query.To != "" {
+					parts = append(parts, query.To)
+				}
+
+				// Join parts with commas and print each query on a new line
+				fmt.Println(strings.Join(parts, ", "))
+			}
 			return nil
 
 		}
@@ -111,30 +93,38 @@ var SavedQueryList = &cobra.Command{
 			}
 		}
 		if d.SavedQueryID() != "" {
-			deleteSavedQuery(&client, d.SavedQueryID(), d.Title())
+			if err := deleteSavedQuery(&client, d.SavedQueryID(), d.Title()); err != nil {
+				return err
+			}
 		}
 		return nil
 	},
 }
 
 // Delete a saved query from the list.
-func deleteSavedQuery(client *internalHTTP.HTTPClient, savedQueryID, title string) {
-	fmt.Printf("\nAttempting to delete '%s'", title)
+func deleteSavedQuery(client *internalHTTP.HTTPClient, savedQueryID, title string) error {
+	fmt.Fprintf(os.Stderr, "\nAttempting to delete '%s'", title)
 	deleteURL := `filters/` + savedQueryID
 	req, err := client.NewRequest("DELETE", deleteURL, nil)
 	if err != nil {
-		fmt.Println("Failed to delete the saved query with error: ", err)
+		return fmt.Errorf("failed to create saved-query delete request: %w", err)
 	}
 
 	resp, err := client.Client.Do(req)
 	if err != nil {
-		return
+		return fmt.Errorf("failed to delete saved query: %w", err)
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode == 200 {
-		fmt.Printf("\nSaved Query deleted\n\n")
+	if resp.StatusCode != http.StatusOK {
+		body, readErr := io.ReadAll(resp.Body)
+		if readErr != nil {
+			return fmt.Errorf("failed to read saved-query delete response: %w", readErr)
+		}
+		return responseStatusError("delete saved query", resp.StatusCode, resp.Status, body)
 	}
+	fmt.Printf("\nSaved Query deleted\n\n")
+	return nil
 }
 
 // Convert a saved query to executable SQL query and print results to terminal.
@@ -178,35 +168,34 @@ type Item struct {
 	To     string `json:"to,omitempty"`
 }
 
-func fetchFilters(client *internalHTTP.HTTPClient) []Item {
+func fetchFilters(client *internalHTTP.HTTPClient) ([]Item, error) {
 	req, err := client.NewRequest("GET", "filters", nil)
 	if err != nil {
-		fmt.Println("Error creating request:", err)
-		return nil
+		return nil, fmt.Errorf("failed to create saved-query request: %w", err)
 	}
 
 	resp, err := client.Client.Do(req)
 	if err != nil {
-		fmt.Println("Error making request:", err)
-		return nil
+		return nil, fmt.Errorf("failed to fetch saved queries: %w", err)
 	}
 	defer resp.Body.Close()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		fmt.Println("Error reading response body:", err)
-		return nil
+		return nil, fmt.Errorf("failed to read saved-query response: %w", err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		legacyMessage := fmt.Sprintf("failed to fetch saved queries: %s: %s", resp.Status, strings.TrimSpace(string(body)))
+		return nil, httpStatusCLIError(resp.StatusCode, legacyMessage, fmt.Sprintf("failed to fetch saved queries: %s", resp.Status))
 	}
 
 	var filters []model.Filter
-	err = json.Unmarshal(body, &filters)
-	if err != nil {
-		fmt.Println("Error unmarshalling response:", err)
-		return nil
+	if err := json.Unmarshal(body, &filters); err != nil {
+		return nil, fmt.Errorf("failed to decode saved-query response: %w", err)
 	}
 
 	// This returns only the SQL type filters
-	var userSavedQueries []Item
+	userSavedQueries := make([]Item, 0, len(filters))
 	for _, filter := range filters {
 		if filter.Query.FilterQuery == nil {
 			continue
@@ -221,5 +210,5 @@ func fetchFilters(client *internalHTTP.HTTPClient) []Item {
 		}
 		userSavedQueries = append(userSavedQueries, userSavedQuery)
 	}
-	return userSavedQueries
+	return userSavedQueries, nil
 }

--- a/cmd/queryList_test.go
+++ b/cmd/queryList_test.go
@@ -3,9 +3,21 @@ package cmd
 import (
 	"bytes"
 	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
+
+	"github.com/parseablehq/pb/pkg/config"
+	internalHTTP "github.com/parseablehq/pb/pkg/http"
 )
+
+type savedQueryRoundTripFunc func(*http.Request) (*http.Response, error)
+
+func (fn savedQueryRoundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return fn(req)
+}
 
 func TestSavedQueryToPbQueryPrintsEmptyQueryMessage(t *testing.T) {
 	var output bytes.Buffer
@@ -31,5 +43,69 @@ func TestSavedQueryToPbQueryPrintsEmptyQueryMessage(t *testing.T) {
 	}
 	if got, want := output.String(), "Empty query selected.\n"; got != want {
 		t.Fatalf("unexpected output\nwant: %q\n got: %q", want, got)
+	}
+}
+
+func TestFetchFiltersReturnsEmptyArrayForNoSavedQueries(t *testing.T) {
+	profile := config.Profile{URL: "https://example.com", APIKey: "test-key"}
+	client := internalHTTP.DefaultClientWithTransport(&profile, savedQueryRoundTripFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Status:     "200 OK",
+			Body:       io.NopCloser(strings.NewReader(`[]`)),
+		}, nil
+	}))
+
+	items, err := fetchFilters(&client)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if items == nil || len(items) != 0 {
+		t.Fatalf("expected non-nil empty result, got %#v", items)
+	}
+}
+
+func TestFetchFiltersReturnsServerErrors(t *testing.T) {
+	profile := config.Profile{URL: "https://example.com", APIKey: "test-key"}
+	client := internalHTTP.DefaultClientWithTransport(&profile, savedQueryRoundTripFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusForbidden,
+			Status:     "403 Forbidden",
+			Body:       io.NopCloser(strings.NewReader(`denied`)),
+		}, nil
+	}))
+
+	if _, err := fetchFilters(&client); err == nil || !strings.Contains(err.Error(), "403 Forbidden") {
+		t.Fatalf("expected server error, got %v", err)
+	}
+}
+
+func TestSavedQueryListJSONBypassesInteractiveMenu(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if request.URL.Path != "/api/v1/filters" {
+			t.Fatalf("unexpected request path: %s", request.URL.Path)
+		}
+		writer.Header().Set("Content-Type", "application/json")
+		_, _ = writer.Write([]byte(`[]`))
+	}))
+	t.Cleanup(server.Close)
+
+	previousProfile := DefaultProfile
+	previousOutput := outputFlag
+	DefaultProfile = config.Profile{URL: server.URL, APIKey: "test-key"}
+	outputFlag = outputJSON
+	t.Cleanup(func() {
+		DefaultProfile = previousProfile
+		outputFlag = previousOutput
+		SavedQueryList.SetOut(nil)
+	})
+
+	var stdout bytes.Buffer
+	SavedQueryList.SetOut(&stdout)
+	if err := SavedQueryList.RunE(SavedQueryList, nil); err != nil {
+		t.Fatal(err)
+	}
+	if stdout.String() != "[]\n" {
+		t.Fatalf("unexpected JSON output: %q", stdout.String())
 	}
 }

--- a/cmd/role.go
+++ b/cmd/role.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net/http"
 	"strings"
 	"sync"
 	"time"
@@ -88,8 +89,9 @@ var AddRoleCmd = &cobra.Command{
 		}
 
 		if slices.Contains(roles, name) {
-			fmt.Println("role already exists, please use a different name")
-			return nil
+			commandErr := newCLIError(ErrorConflict, fmt.Sprintf("role %s already exists; use a different name", name), nil)
+			cmd.Annotations["errors"] = commandErr.Error()
+			return commandErr
 		}
 
 		_m, err := tea.NewProgram(role.New()).Run()
@@ -132,15 +134,12 @@ var AddRoleCmd = &cobra.Command{
 			cmd.Annotations["errors"] = fmt.Sprintf("Error reading response: %s", err.Error())
 			return err
 		}
-		body := string(bodyBytes)
-
-		if resp.StatusCode == 200 {
-			fmt.Printf("Added role %s", name)
-		} else {
-			cmd.Annotations["errors"] = fmt.Sprintf("Request failed - Status: %s, Response: %s", resp.Status, body)
-			fmt.Printf("Request Failed\nStatus Code: %s\nResponse: %s\n", resp.Status, body)
+		if resp.StatusCode != http.StatusOK {
+			requestErr := responseStatusError("create role", resp.StatusCode, resp.Status, bodyBytes)
+			cmd.Annotations["errors"] = requestErr.Error()
+			return requestErr
 		}
-
+		fmt.Printf("Added role %s", name)
 		return nil
 	},
 }
@@ -167,9 +166,9 @@ var RemoveRoleCmd = &cobra.Command{
 			return err
 		}
 		if !slices.Contains(roles, name) {
-			fmt.Println(missingRoleMessage(name, roles))
-			cmd.Annotations["errors"] = fmt.Sprintf("role %s does not exist", name)
-			return nil
+			commandErr := fmt.Errorf("%s", missingRoleMessage(name, roles))
+			cmd.Annotations["errors"] = commandErr.Error()
+			return commandErr
 		}
 
 		req, err := client.NewRequest("DELETE", "role/"+name, nil)
@@ -185,19 +184,17 @@ var RemoveRoleCmd = &cobra.Command{
 		}
 		defer resp.Body.Close()
 
-		if resp.StatusCode == 200 {
-			fmt.Printf("Removed role %s\n", StyleBold.Render(name))
-		} else {
+		if resp.StatusCode != http.StatusOK {
 			bodyBytes, err := io.ReadAll(resp.Body)
 			if err != nil {
 				cmd.Annotations["errors"] = fmt.Sprintf("Error reading response: %s", err.Error())
 				return err
 			}
-			body := string(bodyBytes)
-			cmd.Annotations["errors"] = fmt.Sprintf("Request failed - Status: %s, Response: %s", resp.Status, body)
-			fmt.Printf("Request Failed\nStatus Code: %s\nResponse: %s\n", resp.Status, body)
+			requestErr := responseStatusError("delete role", resp.StatusCode, resp.Status, bodyBytes)
+			cmd.Annotations["errors"] = requestErr.Error()
+			return requestErr
 		}
-
+		fmt.Printf("Removed role %s\n", StyleBold.Render(name))
 		return nil
 	},
 }
@@ -223,7 +220,7 @@ var ListRoleCmd = &cobra.Command{
 			return err
 		}
 
-		outputFormat, err := cmd.Flags().GetString("output")
+		outputFormat, err := commandOutputFormat(cmd)
 		if err != nil {
 			cmd.Annotations["errors"] = fmt.Sprintf("Error retrieving output flag: %s", err.Error())
 			return err
@@ -243,24 +240,6 @@ var ListRoleCmd = &cobra.Command{
 			}(idx, role)
 		}
 		wg.Wait()
-
-		if outputFormat == "json" {
-			allRoles := map[string][]RoleData{}
-			for idx, roleName := range roles {
-				if roleResponses[idx].err == nil {
-					allRoles[roleName] = roleResponses[idx].data
-				}
-			}
-			jsonOutput, err := json.MarshalIndent(allRoles, "", "  ")
-			if err != nil {
-				cmd.Annotations["errors"] = fmt.Sprintf("Error marshaling JSON output: %s", err.Error())
-				return fmt.Errorf("failed to marshal JSON output: %w", err)
-			}
-			fmt.Println(string(jsonOutput))
-			return nil
-		}
-
-		printRoleTable(roles, roleResponses)
 		var fetchErrors []string
 		for idx, roleName := range roles {
 			if roleResponses[idx].err != nil {
@@ -269,11 +248,26 @@ var ListRoleCmd = &cobra.Command{
 				cmd.Annotations["errors"] += errMsg + "\n"
 			}
 		}
+		var detailsErr error
 		if len(fetchErrors) > 0 {
-			return fmt.Errorf("failed to fetch details for %d role(s): %s", len(fetchErrors), strings.Join(fetchErrors, "; "))
+			detailsErr = fmt.Errorf("failed to fetch details for %d role(s): %s", len(fetchErrors), strings.Join(fetchErrors, "; "))
 		}
 
-		return nil
+		if outputFormat == outputJSON {
+			allRoles := map[string][]RoleData{}
+			for idx, roleName := range roles {
+				if roleResponses[idx].err == nil {
+					allRoles[roleName] = roleResponses[idx].data
+				}
+			}
+			if err := writeJSON(cmd.OutOrStdout(), allRoles); err != nil {
+				return err
+			}
+			return detailsErr
+		}
+
+		printRoleTable(roles, roleResponses)
+		return detailsErr
 	},
 }
 
@@ -459,7 +453,8 @@ func fetchRoles(client *internalHTTP.HTTPClient, data *[]string) error {
 		}
 	} else {
 		body := string(bytes)
-		return fmt.Errorf("request failed\nstatus code: %s\nresponse: %s", resp.Status, body)
+		legacyMessage := fmt.Sprintf("request failed\nstatus code: %s\nresponse: %s", resp.Status, body)
+		return httpStatusCLIError(resp.StatusCode, legacyMessage, fmt.Sprintf("request failed: %s", resp.Status))
 	}
 
 	return nil
@@ -492,7 +487,8 @@ func fetchSpecificRole(client *internalHTTP.HTTPClient, role string) (res []Role
 		res = wrapper.Actions
 	} else {
 		body := string(bytes)
-		err = fmt.Errorf("request failed\nstatus code: %s\nresponse: %s", resp.Status, body)
+		legacyMessage := fmt.Sprintf("request failed\nstatus code: %s\nresponse: %s", resp.Status, body)
+		err = httpStatusCLIError(resp.StatusCode, legacyMessage, fmt.Sprintf("request failed: %s", resp.Status))
 		return
 	}
 

--- a/cmd/role.go
+++ b/cmd/role.go
@@ -166,7 +166,7 @@ var RemoveRoleCmd = &cobra.Command{
 			return err
 		}
 		if !slices.Contains(roles, name) {
-			commandErr := fmt.Errorf("%s", missingRoleMessage(name, roles))
+			commandErr := newCLIError(ErrorNotFound, missingRoleMessage(name, roles), nil)
 			cmd.Annotations["errors"] = commandErr.Error()
 			return commandErr
 		}
@@ -254,6 +254,9 @@ var ListRoleCmd = &cobra.Command{
 		}
 
 		if outputFormat == outputJSON {
+			if detailsErr != nil {
+				return detailsErr
+			}
 			allRoles := map[string][]RoleData{}
 			for idx, roleName := range roles {
 				if roleResponses[idx].err == nil {
@@ -263,7 +266,7 @@ var ListRoleCmd = &cobra.Command{
 			if err := writeJSON(cmd.OutOrStdout(), allRoles); err != nil {
 				return err
 			}
-			return detailsErr
+			return nil
 		}
 
 		printRoleTable(roles, roleResponses)

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -16,9 +16,9 @@
 package cmd
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
@@ -34,7 +34,7 @@ var StatusCmd = &cobra.Command{
 	Short:   "Check connection status for the active profile",
 	Example: "  pb status\n  pb status -o json",
 	RunE: func(cmd *cobra.Command, _ []string) error {
-		outputFormat, err := cmd.Flags().GetString("output")
+		outputFormat, err := commandOutputFormat(cmd)
 		if err != nil {
 			return err
 		}
@@ -50,16 +50,11 @@ var StatusCmd = &cobra.Command{
 			return statusPreflightError(outputFormat, "no active profile. run: pb login")
 		}
 
-		if outputFormat != "json" {
-			fmt.Printf("Profile : %s\n", profileName)
-			fmt.Printf("URL     : %s\n", profile.URL)
-		}
-
 		client := internalHTTP.DefaultClient(&profile)
 		about, err := analytics.FetchAbout(&client)
 		if err != nil {
 			statusMessage := statusErrorMessage(err)
-			if outputFormat == "json" {
+			if outputFormat == outputJSON {
 				if jsonErr := printStatusJSON(statusOutput{
 					Status:  "error",
 					Healthy: false,
@@ -69,15 +64,17 @@ var StatusCmd = &cobra.Command{
 				}); jsonErr != nil {
 					return jsonErr
 				}
-			} else {
-				errStyle := lipgloss.NewStyle().Foreground(ui.Active.Err).Bold(true)
-				fmt.Printf("Status  : %s\n", errStyle.Render("✗ Not connected"))
-				fmt.Printf("Error   : %s\n", statusMessage)
+				return MarkErrorRendered(fmt.Errorf("status check failed: %s", statusMessage))
 			}
+			errStyle := lipgloss.NewStyle().Foreground(ui.Active.Err).Bold(true)
+			fmt.Fprintf(cmd.ErrOrStderr(), "Profile : %s\n", profileName)
+			fmt.Fprintf(cmd.ErrOrStderr(), "URL     : %s\n", profile.URL)
+			fmt.Fprintf(cmd.ErrOrStderr(), "Status  : %s\n", errStyle.Render("✗ Not connected"))
+			fmt.Fprintf(cmd.ErrOrStderr(), "Error   : %s\n", statusMessage)
 			return fmt.Errorf("status check failed: %s", statusMessage)
 		}
 
-		if outputFormat == "json" {
+		if outputFormat == outputJSON {
 			return printStatusJSON(statusOutput{
 				Status:  "ok",
 				Healthy: true,
@@ -88,6 +85,8 @@ var StatusCmd = &cobra.Command{
 		}
 
 		okStyle := lipgloss.NewStyle().Foreground(ui.Active.Ok).Bold(true)
+		fmt.Printf("Profile : %s\n", profileName)
+		fmt.Printf("URL     : %s\n", profile.URL)
 		fmt.Printf("Status  : %s\n", okStyle.Render("✓ Connected"))
 		fmt.Printf("Version : %s\n", about.Version)
 		return nil
@@ -104,7 +103,7 @@ type statusOutput struct {
 }
 
 func statusPreflightError(outputFormat, message string) error {
-	if outputFormat == "json" {
+	if outputFormat == outputJSON {
 		if err := printStatusJSON(statusOutput{
 			Status:  "error",
 			Healthy: false,
@@ -112,17 +111,13 @@ func statusPreflightError(outputFormat, message string) error {
 		}); err != nil {
 			return err
 		}
+		return MarkErrorRendered(errors.New(message))
 	}
 	return errors.New(message)
 }
 
 func printStatusJSON(result statusOutput) error {
-	jsonData, err := json.MarshalIndent(result, "", "  ")
-	if err != nil {
-		return fmt.Errorf("failed to marshal status JSON: %w", err)
-	}
-	fmt.Println(string(jsonData))
-	return nil
+	return writeJSON(os.Stdout, result)
 }
 
 func statusErrorMessage(err error) string {

--- a/cmd/tail.go
+++ b/cmd/tail.go
@@ -50,12 +50,9 @@ var TailCmd = &cobra.Command{
 	Args:    cobra.ExactArgs(1),
 	PreRunE: PreRunDefaultProfile,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		output, err := cmd.Flags().GetString("output")
+		output, err := commandOutputFormat(cmd)
 		if err != nil {
 			return err
-		}
-		if output != "text" && output != "json" {
-			return fmt.Errorf("unsupported output format %q (expected text or json)", output)
 		}
 		name := args[0]
 		profile := DefaultProfile

--- a/cmd/user.go
+++ b/cmd/user.go
@@ -112,7 +112,8 @@ var addUser = &cobra.Command{
 		for idx, role := range rolesToSetArr {
 			rolesToSetArr[idx] = strings.TrimSpace(role)
 			if !slices.Contains(rolesOnServer, rolesToSetArr[idx]) {
-				commandErr := fmt.Errorf("role %s doesn't exist; create it first with `pb role add %s`, or use an existing role with `pb user add %s --role <role>`", rolesToSetArr[idx], rolesToSetArr[idx], name)
+				message := fmt.Sprintf("role %s doesn't exist; create it first with `pb role add %s`, or use an existing role with `pb user add %s --role <role>`", rolesToSetArr[idx], rolesToSetArr[idx], name)
+				commandErr := newCLIError(ErrorNotFound, message, nil)
 				cmd.Annotations["error"] = commandErr.Error()
 				return commandErr
 			}
@@ -227,7 +228,7 @@ var SetUserRoleCmd = &cobra.Command{
 		if !slices.ContainsFunc(users, func(user UserData) bool {
 			return user.ID == name
 		}) {
-			commandErr := fmt.Errorf("%s", missingUserMessage(name, DefaultProfile.Cloud))
+			commandErr := newCLIError(ErrorNotFound, missingUserMessage(name, DefaultProfile.Cloud), nil)
 			cmd.Annotations["error"] = commandErr.Error()
 			return commandErr
 		}
@@ -242,7 +243,8 @@ var SetUserRoleCmd = &cobra.Command{
 		for idx, role := range rolesToSetArr {
 			rolesToSetArr[idx] = strings.TrimSpace(role)
 			if !slices.Contains(rolesOnServer, rolesToSetArr[idx]) {
-				commandErr := fmt.Errorf("role %s doesn't exist; create it using `pb role add %s`", rolesToSetArr[idx], rolesToSetArr[idx])
+				message := fmt.Sprintf("role %s doesn't exist; create it using `pb role add %s`", rolesToSetArr[idx], rolesToSetArr[idx])
+				commandErr := newCLIError(ErrorNotFound, message, nil)
 				cmd.Annotations["error"] = commandErr.Error()
 				return commandErr
 			}
@@ -363,6 +365,9 @@ var ListUserCmd = &cobra.Command{
 		}
 
 		if outputFormat == outputJSON {
+			if err := userRoleFetchError(cmd, users, roleResponses); err != nil {
+				return err
+			}
 			usersWithRoles := make([]map[string]interface{}, len(users))
 			for idx, user := range users {
 				usersWithRoles[idx] = map[string]interface{}{
@@ -374,7 +379,7 @@ var ListUserCmd = &cobra.Command{
 				cmd.Annotations["error"] = err.Error()
 				return err
 			}
-			return userRoleFetchError(cmd, users, roleResponses)
+			return nil
 		}
 
 		printUserRoleTable(users, roleResponses)

--- a/cmd/user.go
+++ b/cmd/user.go
@@ -74,9 +74,9 @@ var addUser = &cobra.Command{
 
 		name := args[0]
 		if DefaultProfile.Cloud {
-			fmt.Println(cloudAddUserMessage())
-			cmd.Annotations["error"] = "user creation is not supported for cloud profiles"
-			return nil
+			commandErr := newCLIError(ErrorInvalidInput, cloudAddUserMessage(), nil)
+			cmd.Annotations["error"] = commandErr.Error()
+			return commandErr
 		}
 
 		client := internalHTTP.DefaultClient(&DefaultProfile)
@@ -89,9 +89,9 @@ var addUser = &cobra.Command{
 		if slices.ContainsFunc(users, func(user UserData) bool {
 			return user.ID == name
 		}) {
-			fmt.Println("user already exists")
-			cmd.Annotations["error"] = "user already exists"
-			return nil
+			commandErr := newCLIError(ErrorConflict, fmt.Sprintf("user %s already exists", name), nil)
+			cmd.Annotations["error"] = commandErr.Error()
+			return commandErr
 		}
 
 		// fetch all the roles to be applied to this user
@@ -102,9 +102,9 @@ var addUser = &cobra.Command{
 			return err
 		}
 		if rolesToSet == "" {
-			fmt.Println(selfHostedAddUserRoleMessage(name, rolesOnServer))
-			cmd.Annotations["error"] = "at least one role is required"
-			return nil
+			commandErr := newCLIError(ErrorInvalidInput, selfHostedAddUserRoleMessage(name, rolesOnServer), nil)
+			cmd.Annotations["error"] = commandErr.Error()
+			return commandErr
 		}
 		rolesToSetArr := strings.Split(rolesToSet, ",")
 
@@ -112,9 +112,9 @@ var addUser = &cobra.Command{
 		for idx, role := range rolesToSetArr {
 			rolesToSetArr[idx] = strings.TrimSpace(role)
 			if !slices.Contains(rolesOnServer, rolesToSetArr[idx]) {
-				fmt.Printf("role %s doesn't exist. Create it first with `pb role add %s`, or use an existing role with `pb user add %s --role <role>`\n", rolesToSetArr[idx], rolesToSetArr[idx], name)
-				cmd.Annotations["error"] = fmt.Sprintf("role %s doesn't exist", rolesToSetArr[idx])
-				return nil
+				commandErr := fmt.Errorf("role %s doesn't exist; create it first with `pb role add %s`, or use an existing role with `pb user add %s --role <role>`", rolesToSetArr[idx], rolesToSetArr[idx], name)
+				cmd.Annotations["error"] = commandErr.Error()
+				return commandErr
 			}
 		}
 
@@ -132,23 +132,20 @@ var addUser = &cobra.Command{
 			cmd.Annotations["error"] = err.Error()
 			return err
 		}
+		defer resp.Body.Close()
 
-		bytes, err := io.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			cmd.Annotations["error"] = err.Error()
 			return err
 		}
-		body := string(bytes)
-		defer resp.Body.Close()
-
-		if resp.StatusCode == 200 {
-			fmt.Printf("Added user: %s \nPassword is: %s\nRole(s) assigned: %s\n", name, body, rolesToSet)
-			cmd.Annotations["error"] = "none"
-		} else {
-			fmt.Printf("Request Failed\nStatus Code: %s\nResponse: %s\n", resp.Status, body)
-			cmd.Annotations["error"] = fmt.Sprintf("request failed with status code %s", resp.Status)
+		if resp.StatusCode != http.StatusOK {
+			requestErr := responseStatusError("create user", resp.StatusCode, resp.Status, body)
+			cmd.Annotations["error"] = requestErr.Error()
+			return requestErr
 		}
-
+		fmt.Printf("Added user: %s \nPassword is: %s\nRole(s) assigned: %s\n", name, string(body), rolesToSet)
+		cmd.Annotations["error"] = "none"
 		return nil
 	},
 }
@@ -184,16 +181,19 @@ var RemoveUserCmd = &cobra.Command{
 			cmd.Annotations["error"] = err.Error()
 			return err
 		}
+		defer resp.Body.Close()
 
-		if resp.StatusCode == 200 {
-			fmt.Printf("Removed user %s\n", StyleBold.Render(name))
-			cmd.Annotations["error"] = "none"
-		} else {
-			body, _ := io.ReadAll(resp.Body)
-			fmt.Printf("Request Failed\nStatus Code: %s\nResponse: %s\n", resp.Status, string(body))
-			cmd.Annotations["error"] = fmt.Sprintf("request failed with status code %s", resp.Status)
+		if resp.StatusCode != http.StatusOK {
+			body, readErr := io.ReadAll(resp.Body)
+			if readErr != nil {
+				return readErr
+			}
+			requestErr := responseStatusError("delete user", resp.StatusCode, resp.Status, body)
+			cmd.Annotations["error"] = requestErr.Error()
+			return requestErr
 		}
-
+		fmt.Printf("Removed user %s\n", StyleBold.Render(name))
+		cmd.Annotations["error"] = "none"
 		return nil
 	},
 }
@@ -227,9 +227,9 @@ var SetUserRoleCmd = &cobra.Command{
 		if !slices.ContainsFunc(users, func(user UserData) bool {
 			return user.ID == name
 		}) {
-			fmt.Println(missingUserMessage(name, DefaultProfile.Cloud))
-			cmd.Annotations["error"] = "user does not exist"
-			return nil
+			commandErr := fmt.Errorf("%s", missingUserMessage(name, DefaultProfile.Cloud))
+			cmd.Annotations["error"] = commandErr.Error()
+			return commandErr
 		}
 
 		rolesToSet := args[1]
@@ -242,9 +242,9 @@ var SetUserRoleCmd = &cobra.Command{
 		for idx, role := range rolesToSetArr {
 			rolesToSetArr[idx] = strings.TrimSpace(role)
 			if !slices.Contains(rolesOnServer, rolesToSetArr[idx]) {
-				fmt.Printf("role %s doesn't exist, please create a role using `pb role add %s`\n", rolesToSetArr[idx], rolesToSetArr[idx])
-				cmd.Annotations["error"] = fmt.Sprintf("role %s doesn't exist", rolesToSetArr[idx])
-				return nil
+				commandErr := fmt.Errorf("role %s doesn't exist; create it using `pb role add %s`", rolesToSetArr[idx], rolesToSetArr[idx])
+				cmd.Annotations["error"] = commandErr.Error()
+				return commandErr
 			}
 		}
 
@@ -259,23 +259,20 @@ var SetUserRoleCmd = &cobra.Command{
 			cmd.Annotations["error"] = err.Error()
 			return err
 		}
+		defer resp.Body.Close()
 
-		bytes, err := io.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			cmd.Annotations["error"] = err.Error()
 			return err
 		}
-		body := string(bytes)
-		defer resp.Body.Close()
-
-		if resp.StatusCode == 200 {
-			fmt.Printf("Added role(s) %s to user %s\n", rolesToSet, name)
-			cmd.Annotations["error"] = "none"
-		} else {
-			fmt.Printf("Request Failed\nStatus Code: %s\nResponse: %s\n", resp.Status, body)
-			cmd.Annotations["error"] = fmt.Sprintf("request failed with status code %s", resp.Status)
+		if resp.StatusCode != http.StatusOK {
+			requestErr := responseStatusError("set user roles", resp.StatusCode, resp.Status, body)
+			cmd.Annotations["error"] = requestErr.Error()
+			return requestErr
 		}
-
+		fmt.Printf("Added role(s) %s to user %s\n", rolesToSet, name)
+		cmd.Annotations["error"] = "none"
 		return nil
 	},
 }
@@ -359,31 +356,24 @@ var ListUserCmd = &cobra.Command{
 
 		wsg.Wait()
 
-		outputFormat, err := cmd.Flags().GetString("output")
+		outputFormat, err := commandOutputFormat(cmd)
 		if err != nil {
 			cmd.Annotations["error"] = err.Error()
 			return err
 		}
 
-		if outputFormat == "json" {
+		if outputFormat == outputJSON {
 			usersWithRoles := make([]map[string]interface{}, len(users))
 			for idx, user := range users {
 				usersWithRoles[idx] = map[string]interface{}{
 					"id":    user.ID,
-					"roles": roleResponses[idx].data,
+					"roles": nonNilSlice(roleResponses[idx].data),
 				}
 			}
-			jsonOutput, err := json.MarshalIndent(usersWithRoles, "", "  ")
-			if err != nil {
+			if err := writeJSON(cmd.OutOrStdout(), usersWithRoles); err != nil {
 				cmd.Annotations["error"] = err.Error()
-				return fmt.Errorf("failed to marshal JSON output: %w", err)
+				return err
 			}
-			fmt.Println(string(jsonOutput))
-			return userRoleFetchError(cmd, users, roleResponses)
-		}
-
-		if outputFormat == "text" {
-			printUserRoleTable(users, roleResponses)
 			return userRoleFetchError(cmd, users, roleResponses)
 		}
 
@@ -525,7 +515,8 @@ func fetchUsers(client *internalHTTP.HTTPClient) (res []UserData, err error) {
 		}
 	} else {
 		body := string(bytes)
-		err = fmt.Errorf("request failed\nstatus code: %s\nresponse: %s", resp.Status, body)
+		legacyMessage := fmt.Sprintf("request failed\nstatus code: %s\nresponse: %s", resp.Status, body)
+		err = httpStatusCLIError(resp.StatusCode, legacyMessage, fmt.Sprintf("request failed: %s", resp.Status))
 		return
 	}
 
@@ -541,11 +532,15 @@ func fetchUserRoles(client *internalHTTP.HTTPClient, user string) (res UserRoles
 	if err != nil {
 		return
 	}
+	defer resp.Body.Close()
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return
 	}
-	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		err = responseStatusError("fetch user roles", resp.StatusCode, resp.Status, body)
+		return
+	}
 
 	err = json.Unmarshal(body, &res)
 	return

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -17,7 +17,6 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 	"time"
 
 	"github.com/parseablehq/pb/pkg/analytics"
@@ -42,7 +41,7 @@ var VersionCmd = &cobra.Command{
 			cmd.Annotations["executionTime"] = time.Since(startTime).String()
 		}()
 
-		err := PrintVersion("1.0.0", "abc123") // Replace with actual version and commit values
+		err := PrintVersion(cmd, "1.0.0", "abc123") // Replace with actual version and commit values
 		if err != nil {
 			cmd.Annotations["error"] = err.Error()
 		}
@@ -51,12 +50,12 @@ var VersionCmd = &cobra.Command{
 }
 
 func init() {
-	VersionCmd.Flags().StringVarP(&outputFormat, "output", "o", "text", "Output format (text|json)")
+	VersionCmd.Flags().StringP("output", "o", "text", "Output format (text|json)")
 }
 
 // PrintVersion prints version information
-func PrintVersion(version, commit string) error {
-	format, err := validateOutputFormat(outputFormat)
+func PrintVersion(cmd *cobra.Command, version, commit string) error {
+	format, err := commandOutputFormat(cmd)
 	if err != nil {
 		return err
 	}
@@ -85,17 +84,18 @@ func PrintVersion(version, commit string) error {
 				"commit":  about.Commit,
 			},
 		}
-		return writeJSON(os.Stdout, versionInfo)
+		return writeJSON(cmd.OutOrStdout(), versionInfo)
 	}
 
 	// Default: Output as text
-	fmt.Printf("\n%s \n", StandardStyleAlt.Render("pb version"))
-	fmt.Printf("- %s %s\n", StandardStyleBold.Render("version: "), version)
-	fmt.Printf("- %s %s\n\n", StandardStyleBold.Render("commit:  "), commit)
+	out := cmd.OutOrStdout()
+	fmt.Fprintf(out, "\n%s \n", StandardStyleAlt.Render("pb version"))
+	fmt.Fprintf(out, "- %s %s\n", StandardStyleBold.Render("version: "), version)
+	fmt.Fprintf(out, "- %s %s\n\n", StandardStyleBold.Render("commit:  "), commit)
 
-	fmt.Printf("%s %s \n", StandardStyleAlt.Render("Connected to"), StandardStyleBold.Render(DefaultProfile.URL))
-	fmt.Printf("- %s %s\n", StandardStyleBold.Render("version: "), about.Version)
-	fmt.Printf("- %s %s\n\n", StandardStyleBold.Render("commit:  "), about.Commit)
+	fmt.Fprintf(out, "%s %s \n", StandardStyleAlt.Render("Connected to"), StandardStyleBold.Render(DefaultProfile.URL))
+	fmt.Fprintf(out, "- %s %s\n", StandardStyleBold.Render("version: "), about.Version)
+	fmt.Fprintf(out, "- %s %s\n\n", StandardStyleBold.Render("commit:  "), about.Commit)
 
 	return nil
 }

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -16,8 +16,8 @@
 package cmd
 
 import (
-	"encoding/json"
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/parseablehq/pb/pkg/analytics"
@@ -31,7 +31,7 @@ var VersionCmd = &cobra.Command{
 	Short:   "Print version",
 	Long:    "Print version and commit information",
 	Example: "  pb version",
-	Run: func(cmd *cobra.Command, _ []string) {
+	RunE: func(cmd *cobra.Command, _ []string) error {
 		if cmd.Annotations == nil {
 			cmd.Annotations = make(map[string]string)
 		}
@@ -46,6 +46,7 @@ var VersionCmd = &cobra.Command{
 		if err != nil {
 			cmd.Annotations["error"] = err.Error()
 		}
+		return err
 	},
 }
 
@@ -55,6 +56,10 @@ func init() {
 
 // PrintVersion prints version information
 func PrintVersion(version, commit string) error {
+	format, err := validateOutputFormat(outputFormat)
+	if err != nil {
+		return err
+	}
 	client := internalHTTP.DefaultClient(&DefaultProfile)
 
 	// Fetch server information
@@ -68,7 +73,7 @@ func PrintVersion(version, commit string) error {
 	}
 
 	// Output as JSON if specified
-	if outputFormat == "json" {
+	if format == outputJSON {
 		versionInfo := map[string]interface{}{
 			"client": map[string]string{
 				"version": version,
@@ -80,12 +85,7 @@ func PrintVersion(version, commit string) error {
 				"commit":  about.Commit,
 			},
 		}
-		jsonData, err := json.MarshalIndent(versionInfo, "", "  ")
-		if err != nil {
-			return fmt.Errorf("error generating JSON output: %w", err)
-		}
-		fmt.Println(string(jsonData))
-		return nil
+		return writeJSON(os.Stdout, versionInfo)
 	}
 
 	// Default: Output as text

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -1,0 +1,48 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/parseablehq/pb/pkg/config"
+	"github.com/spf13/cobra"
+)
+
+func TestPrintVersionUsesCallingCommandOutputFormat(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	if err := config.WriteConfigToFile(&config.Config{
+		Profiles: map[string]config.Profile{
+			"test": {URL: "https://example.com", APIKey: "test-key"},
+		},
+		DefaultProfile: "test",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	useCommandTransport(t, func(*http.Request) (*http.Response, error) {
+		return commandHTTPResponse(http.StatusOK, "200 OK", `{"version":"v2","commit":"server-commit"}`), nil
+	})
+
+	command := &cobra.Command{Use: "pb"}
+	command.Flags().StringP("output", "o", "text", "output format")
+	if err := command.Flags().Set("output", "json"); err != nil {
+		t.Fatal(err)
+	}
+	var output bytes.Buffer
+	command.SetOut(&output)
+
+	if err := PrintVersion(command, "v1", "client-commit"); err != nil {
+		t.Fatal(err)
+	}
+	var result struct {
+		Client map[string]string `json:"client"`
+		Server map[string]string `json:"server"`
+	}
+	if err := json.Unmarshal(output.Bytes(), &result); err != nil {
+		t.Fatalf("invalid version JSON %q: %v", output.String(), err)
+	}
+	if result.Client["version"] != "v1" || result.Server["version"] != "v2" {
+		t.Fatalf("unexpected version output: %+v", result)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -54,7 +54,7 @@ var cli = &cobra.Command{
 	PersistentPreRunE: analyticsPreRun,
 	RunE: func(command *cobra.Command, _ []string) error {
 		if p, _ := command.Flags().GetBool(versionFlag); p {
-			return pb.PrintVersion(Version, Commit)
+			return pb.PrintVersion(command, Version, Commit)
 		}
 		output, err := normalizeOutputFormat(rootOutputFormat)
 		if err != nil {
@@ -294,8 +294,8 @@ func main() {
 
 	// Set as command
 	pb.VersionCmd.Run = nil
-	pb.VersionCmd.RunE = func(_ *cobra.Command, _ []string) error {
-		return pb.PrintVersion(Version, Commit)
+	pb.VersionCmd.RunE = func(command *cobra.Command, _ []string) error {
+		return pb.PrintVersion(command, Version, Commit)
 	}
 
 	cli.AddCommand(pb.VersionCmd)

--- a/main.go
+++ b/main.go
@@ -56,11 +56,12 @@ var cli = &cobra.Command{
 		if p, _ := command.Flags().GetBool(versionFlag); p {
 			return pb.PrintVersion(Version, Commit)
 		}
-		if rootOutputFormat == "json" {
-			return printCommandJSON(command)
+		output, err := normalizeOutputFormat(rootOutputFormat)
+		if err != nil {
+			return err
 		}
-		if rootOutputFormat != "text" {
-			return fmt.Errorf("unsupported output format %q (expected text or json)", rootOutputFormat)
+		if output == "json" {
+			return printCommandJSON(command)
 		}
 		return command.Help()
 	},
@@ -312,7 +313,7 @@ func main() {
 	executed, err := cli.ExecuteC()
 	if err != nil {
 		if structuredErrors {
-			if renderErr := renderExecutionError(executed, err); renderErr != nil {
+			if renderErr := renderExecutionError(executed, err, true); renderErr != nil {
 				fmt.Fprintf(executed.ErrOrStderr(), "Error: %v\n", renderErr)
 			}
 		}
@@ -338,29 +339,15 @@ func requestsJSONOutput(args []string) bool {
 	return false
 }
 
-func renderExecutionError(command *cobra.Command, err error) error {
+func renderExecutionError(command *cobra.Command, err error, jsonOutput bool) error {
 	if err == nil || pb.ErrorWasRendered(err) {
 		return nil
 	}
-	if executionOutputFormat(command) == "json" {
+	if jsonOutput {
 		return pb.WriteErrorJSON(command.ErrOrStderr(), err)
 	}
 	_, writeErr := fmt.Fprintf(command.ErrOrStderr(), "Error: %v\n", err)
 	return writeErr
-}
-
-func executionOutputFormat(command *cobra.Command) string {
-	if command == nil {
-		return "text"
-	}
-	flag := command.Flags().Lookup("output")
-	if flag == nil {
-		flag = command.InheritedFlags().Lookup("output")
-	}
-	if flag == nil {
-		return "text"
-	}
-	return strings.ToLower(strings.TrimSpace(flag.Value.String()))
 }
 
 type jsonCommand struct {
@@ -420,14 +407,17 @@ func configureParentOutput(cmd *cobra.Command) {
 	cmd.Flags().StringVarP(&output, "output", "o", "text", "Output format (text|json)")
 	cmd.PreRunE = func(_ *cobra.Command, _ []string) error { return nil }
 	cmd.RunE = func(command *cobra.Command, _ []string) error {
-		switch output {
+		format, err := normalizeOutputFormat(output)
+		if err != nil {
+			return err
+		}
+		switch format {
 		case "json":
 			return printCommandJSON(command)
 		case "text":
 			return command.Help()
-		default:
-			return fmt.Errorf("unsupported output format %q (expected text or json)", output)
 		}
+		return nil
 	}
 }
 
@@ -442,17 +432,29 @@ func newHelpCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			if output == "json" {
-				return printCommandJSON(target)
+			format, err := normalizeOutputFormat(output)
+			if err != nil {
+				return err
 			}
-			if output != "text" {
-				return fmt.Errorf("unsupported output format %q (expected text or json)", output)
+			if format == "json" {
+				return printCommandJSON(target)
 			}
 			return target.Help()
 		},
 	}
 	help.Flags().StringVarP(&output, "output", "o", "text", "Output format (text|json)")
 	return help
+}
+
+func normalizeOutputFormat(value string) (string, error) {
+	format := strings.ToLower(strings.TrimSpace(value))
+	if format == "" {
+		format = "text"
+	}
+	if format != "text" && format != "json" {
+		return "", fmt.Errorf("unsupported output format %q (expected text or json)", value)
+	}
+	return format, nil
 }
 
 func renderRootHelp(cmd *cobra.Command, _ []string) {

--- a/main.go
+++ b/main.go
@@ -54,8 +54,7 @@ var cli = &cobra.Command{
 	PersistentPreRunE: analyticsPreRun,
 	RunE: func(command *cobra.Command, _ []string) error {
 		if p, _ := command.Flags().GetBool(versionFlag); p {
-			pb.PrintVersion(Version, Commit)
-			return nil
+			return pb.PrintVersion(Version, Commit)
 		}
 		if rootOutputFormat == "json" {
 			return printCommandJSON(command)
@@ -290,10 +289,12 @@ func main() {
 	cli.AddCommand(pb.CloudCmd)
 	cli.AddCommand(pb.LogoutCmd)
 	cli.AddCommand(pb.StatusCmd)
+	cli.AddCommand(pb.AgentCmd)
 
 	// Set as command
-	pb.VersionCmd.Run = func(_ *cobra.Command, _ []string) {
-		pb.PrintVersion(Version, Commit)
+	pb.VersionCmd.Run = nil
+	pb.VersionCmd.RunE = func(_ *cobra.Command, _ []string) error {
+		return pb.PrintVersion(Version, Commit)
 	}
 
 	cli.AddCommand(pb.VersionCmd)
@@ -304,11 +305,62 @@ func main() {
 	cli.SetHelpFunc(renderRootHelp)
 
 	cli.CompletionOptions.HiddenDefaultCmd = true
+	structuredErrors := requestsJSONOutput(os.Args[1:])
+	cli.SilenceErrors = structuredErrors
+	cli.SilenceUsage = structuredErrors
 
-	err := cli.Execute()
+	executed, err := cli.ExecuteC()
 	if err != nil {
+		if structuredErrors {
+			if renderErr := renderExecutionError(executed, err); renderErr != nil {
+				fmt.Fprintf(executed.ErrOrStderr(), "Error: %v\n", renderErr)
+			}
+		}
 		os.Exit(1)
 	}
+}
+
+func requestsJSONOutput(args []string) bool {
+	for index, arg := range args {
+		lower := strings.ToLower(strings.TrimSpace(arg))
+		if lower == "--" {
+			break
+		}
+		switch lower {
+		case "--output=json", "-o=json", "-ojson":
+			return true
+		case "--output", "-o":
+			if index+1 < len(args) && strings.EqualFold(strings.TrimSpace(args[index+1]), "json") {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func renderExecutionError(command *cobra.Command, err error) error {
+	if err == nil || pb.ErrorWasRendered(err) {
+		return nil
+	}
+	if executionOutputFormat(command) == "json" {
+		return pb.WriteErrorJSON(command.ErrOrStderr(), err)
+	}
+	_, writeErr := fmt.Fprintf(command.ErrOrStderr(), "Error: %v\n", err)
+	return writeErr
+}
+
+func executionOutputFormat(command *cobra.Command) string {
+	if command == nil {
+		return "text"
+	}
+	flag := command.Flags().Lookup("output")
+	if flag == nil {
+		flag = command.InheritedFlags().Lookup("output")
+	}
+	if flag == nil {
+		return "text"
+	}
+	return strings.ToLower(strings.TrimSpace(flag.Value.String()))
 }
 
 type jsonCommand struct {

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	pb "github.com/parseablehq/pb/cmd"
+	"github.com/spf13/cobra"
+)
+
+func TestRenderExecutionErrorJSON(t *testing.T) {
+	command := &cobra.Command{Use: "test"}
+	command.Flags().StringP("output", "o", "text", "output format")
+	if err := command.Flags().Set("output", "json"); err != nil {
+		t.Fatal(err)
+	}
+	var stderr bytes.Buffer
+	command.SetErr(&stderr)
+
+	if err := renderExecutionError(command, errors.New("boom")); err != nil {
+		t.Fatal(err)
+	}
+	var result struct {
+		Error struct {
+			Code    string `json:"code"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(stderr.Bytes(), &result); err != nil {
+		t.Fatalf("stderr is not JSON: %v\n%s", err, stderr.String())
+	}
+	if result.Error.Code != "COMMAND_FAILED" || result.Error.Message != "boom" {
+		t.Fatalf("unexpected error JSON: %+v", result.Error)
+	}
+}
+
+func TestRenderExecutionErrorText(t *testing.T) {
+	command := &cobra.Command{Use: "test"}
+	command.Flags().StringP("output", "o", "text", "output format")
+	var stderr bytes.Buffer
+	command.SetErr(&stderr)
+
+	if err := renderExecutionError(command, errors.New("boom")); err != nil {
+		t.Fatal(err)
+	}
+	if stderr.String() != "Error: boom\n" {
+		t.Fatalf("unexpected text error: %q", stderr.String())
+	}
+}
+
+func TestRenderExecutionErrorSkipsAlreadyRendered(t *testing.T) {
+	command := &cobra.Command{Use: "test"}
+	command.Flags().StringP("output", "o", "json", "output format")
+	var stderr bytes.Buffer
+	command.SetErr(&stderr)
+
+	if err := renderExecutionError(command, pb.MarkErrorRendered(errors.New("boom"))); err != nil {
+		t.Fatal(err)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("already-rendered error was duplicated: %q", stderr.String())
+	}
+}
+
+func TestRequestsJSONOutput(t *testing.T) {
+	tests := []struct {
+		args []string
+		want bool
+	}{
+		{[]string{"dataset", "list", "-o", "json"}, true},
+		{[]string{"dataset", "list", "--output=json"}, true},
+		{[]string{"dataset", "list", "-ojson"}, true},
+		{[]string{"dataset", "list", "-o", "text"}, false},
+		{[]string{"sql", "run", "--", "-ojson"}, false},
+		{[]string{"dataset", "list"}, false},
+	}
+	for _, test := range tests {
+		if got := requestsJSONOutput(test.args); got != test.want {
+			t.Fatalf("requestsJSONOutput(%q) = %t, want %t", test.args, got, test.want)
+		}
+	}
+}

--- a/main_test.go
+++ b/main_test.go
@@ -13,13 +13,13 @@ import (
 func TestRenderExecutionErrorJSON(t *testing.T) {
 	command := &cobra.Command{Use: "test"}
 	command.Flags().StringP("output", "o", "text", "output format")
-	if err := command.Flags().Set("output", "json"); err != nil {
-		t.Fatal(err)
-	}
 	var stderr bytes.Buffer
 	command.SetErr(&stderr)
 
-	if err := renderExecutionError(command, errors.New("boom")); err != nil {
+	// The parsed flag can still have its text default when command discovery
+	// fails before Cobra parses -o json. The raw-argument detector remains the
+	// source of truth for structured errors.
+	if err := renderExecutionError(command, errors.New("boom"), true); err != nil {
 		t.Fatal(err)
 	}
 	var result struct {
@@ -42,7 +42,7 @@ func TestRenderExecutionErrorText(t *testing.T) {
 	var stderr bytes.Buffer
 	command.SetErr(&stderr)
 
-	if err := renderExecutionError(command, errors.New("boom")); err != nil {
+	if err := renderExecutionError(command, errors.New("boom"), false); err != nil {
 		t.Fatal(err)
 	}
 	if stderr.String() != "Error: boom\n" {
@@ -56,7 +56,7 @@ func TestRenderExecutionErrorSkipsAlreadyRendered(t *testing.T) {
 	var stderr bytes.Buffer
 	command.SetErr(&stderr)
 
-	if err := renderExecutionError(command, pb.MarkErrorRendered(errors.New("boom"))); err != nil {
+	if err := renderExecutionError(command, pb.MarkErrorRendered(errors.New("boom")), true); err != nil {
 		t.Fatal(err)
 	}
 	if stderr.Len() != 0 {
@@ -72,6 +72,7 @@ func TestRequestsJSONOutput(t *testing.T) {
 		{[]string{"dataset", "list", "-o", "json"}, true},
 		{[]string{"dataset", "list", "--output=json"}, true},
 		{[]string{"dataset", "list", "-ojson"}, true},
+		{[]string{"dataset", "list", "-o", "JSON"}, true},
 		{[]string{"dataset", "list", "-o", "text"}, false},
 		{[]string{"sql", "run", "--", "-ojson"}, false},
 		{[]string{"dataset", "list"}, false},
@@ -80,5 +81,20 @@ func TestRequestsJSONOutput(t *testing.T) {
 		if got := requestsJSONOutput(test.args); got != test.want {
 			t.Fatalf("requestsJSONOutput(%q) = %t, want %t", test.args, got, test.want)
 		}
+	}
+}
+
+func TestNormalizeOutputFormat(t *testing.T) {
+	for _, input := range []string{"json", "JSON", " json "} {
+		format, err := normalizeOutputFormat(input)
+		if err != nil {
+			t.Fatalf("normalizeOutputFormat(%q): %v", input, err)
+		}
+		if format != "json" {
+			t.Fatalf("normalizeOutputFormat(%q) = %q, want json", input, format)
+		}
+	}
+	if _, err := normalizeOutputFormat("yaml"); err == nil {
+		t.Fatal("expected unsupported output format error")
 	}
 }

--- a/pkg/analytics/analytics.go
+++ b/pkg/analytics/analytics.go
@@ -82,6 +82,14 @@ type Analytics struct {
 	ClarityTag string `json:"clarityTag"`
 }
 
+type httpStatusError struct {
+	statusCode int
+	message    string
+}
+
+func (err httpStatusError) Error() string       { return err.message }
+func (err httpStatusError) HTTPStatusCode() int { return err.statusCode }
+
 type Command struct {
 	Name      string            `json:"name"`
 	Arguments []string          `json:"arguments"`
@@ -97,7 +105,7 @@ type Config struct {
 func CheckAndCreateULID(_ *cobra.Command, _ []string) error {
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
-		fmt.Printf("could not find home directory: %v\n", err)
+		fmt.Fprintf(os.Stderr, "could not find home directory: %v\n", err)
 		return err
 	}
 
@@ -107,7 +115,7 @@ func CheckAndCreateULID(_ *cobra.Command, _ []string) error {
 	if _, err := os.Stat(configPath); os.IsNotExist(err) {
 		// Create the directory if needed
 		if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
-			fmt.Printf("could not create config directory: %v\n", err)
+			fmt.Fprintf(os.Stderr, "could not create config directory: %v\n", err)
 			return err
 		}
 	}
@@ -118,7 +126,7 @@ func CheckAndCreateULID(_ *cobra.Command, _ []string) error {
 	if err == nil {
 		// If the file exists, unmarshal the content
 		if err := yaml.Unmarshal(data, &config); err != nil {
-			fmt.Printf("could not parse config file: %v\n", err)
+			fmt.Fprintf(os.Stderr, "could not parse config file: %v\n", err)
 			return err
 		}
 	}
@@ -132,13 +140,13 @@ func CheckAndCreateULID(_ *cobra.Command, _ []string) error {
 
 		newData, err := yaml.Marshal(&config)
 		if err != nil {
-			fmt.Printf("could not marshal config data: %v\n", err)
+			fmt.Fprintf(os.Stderr, "could not marshal config data: %v\n", err)
 			return err
 		}
 
 		// Write updated config with ULID back to the file
 		if err := os.WriteFile(configPath, newData, 0o644); err != nil {
-			fmt.Printf("could not write to config file: %v\n", err)
+			fmt.Fprintf(os.Stderr, "could not write to config file: %v\n", err)
 			return err
 		}
 		// fmt.Printf("Generated and saved new ULID: %s\n", config.ULID)
@@ -356,7 +364,7 @@ func FetchAbout(client *internalHTTP.HTTPClient) (about About, err error) {
 	} else {
 		body := string(bytes)
 		body = fmt.Sprintf("Request Failed\nStatus Code: %s\nResponse: %s\n", resp.Status, body)
-		err = errors.New(body)
+		err = httpStatusError{statusCode: resp.StatusCode, message: body}
 	}
 	return
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -181,18 +181,18 @@ func WriteConfigToFile(config *Config) error {
 
 	file, err := os.OpenFile(filePath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
 	if err != nil {
-		fmt.Println("Error creating the file:", err)
+		fmt.Fprintln(os.Stderr, "Error creating the file:", err)
 		return err
 	}
 	defer file.Close()
 	if err := file.Chmod(0o600); err != nil {
-		fmt.Println("Error setting file permissions:", err)
+		fmt.Fprintln(os.Stderr, "Error setting file permissions:", err)
 		return err
 	}
 	// Write the data into the file
 	_, err = file.Write(tomlData)
 	if err != nil {
-		fmt.Println("Error writing to the file:", err)
+		fmt.Fprintln(os.Stderr, "Error writing to the file:", err)
 		return err
 	}
 	return err

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -181,21 +181,16 @@ func WriteConfigToFile(config *Config) error {
 
 	file, err := os.OpenFile(filePath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
 	if err != nil {
-		fmt.Fprintln(os.Stderr, "Error creating the file:", err)
-		return err
+		return fmt.Errorf("create config file: %w", err)
 	}
 	defer file.Close()
 	if err := file.Chmod(0o600); err != nil {
-		fmt.Fprintln(os.Stderr, "Error setting file permissions:", err)
-		return err
+		return fmt.Errorf("set config file permissions: %w", err)
 	}
-	// Write the data into the file
-	_, err = file.Write(tomlData)
-	if err != nil {
-		fmt.Fprintln(os.Stderr, "Error writing to the file:", err)
-		return err
+	if _, err := file.Write(tomlData); err != nil {
+		return fmt.Errorf("write config file: %w", err)
 	}
-	return err
+	return nil
 }
 
 // ReadConfigFromFile reads the configuration from the config file

--- a/pkg/datasets/datasets.go
+++ b/pkg/datasets/datasets.go
@@ -45,6 +45,10 @@ func (err httpStatusError) Error() string {
 	return fmt.Sprintf("HTTP %d: %s", err.statusCode, strings.TrimSpace(err.body))
 }
 
+func (err httpStatusError) HTTPStatusCode() int {
+	return err.statusCode
+}
+
 func FetchHomeDatasets(profile config.Profile) ([]Dataset, error) {
 	return fetchPrismHomeDatasets(profile)
 }

--- a/pkg/iterator/iterator.go
+++ b/pkg/iterator/iterator.go
@@ -17,6 +17,7 @@
 package iterator
 
 import (
+	"sync"
 	"time"
 )
 
@@ -26,6 +27,7 @@ type MinuteCheckPoint struct {
 }
 
 type QueryIterator[OK any, ERR any] struct {
+	mu             *sync.RWMutex
 	rangeStartTime time.Time
 	rangeEndTime   time.Time
 	ascending      bool
@@ -39,6 +41,7 @@ type QueryIterator[OK any, ERR any] struct {
 
 func NewQueryIterator[OK any, ERR any](startTime time.Time, endTime time.Time, ascending bool, queryRunner func(time.Time, time.Time) (OK, ERR), hasData func(time.Time, time.Time) bool) QueryIterator[OK, ERR] {
 	iter := QueryIterator[OK, ERR]{
+		mu:             &sync.RWMutex{},
 		rangeStartTime: startTime,
 		rangeEndTime:   endTime,
 		ascending:      ascending,
@@ -58,18 +61,27 @@ func (iter *QueryIterator[OK, ERR]) inRange(targetTime time.Time) bool {
 }
 
 func (iter *QueryIterator[OK, ERR]) Ready() bool {
+	iter.mu.RLock()
+	defer iter.mu.RUnlock()
 	return iter.ready
 }
 
 func (iter *QueryIterator[OK, ERR]) Finished() bool {
+	iter.mu.RLock()
+	defer iter.mu.RUnlock()
 	return iter.finished && iter.index == len(iter.windows)-1
 }
 
 func (iter *QueryIterator[OK, ERR]) CanFetchPrev() bool {
+	iter.mu.RLock()
+	defer iter.mu.RUnlock()
 	return iter.index > 0
 }
 
 func (iter *QueryIterator[OK, ERR]) populateNextNonEmpty() {
+	iter.mu.Lock()
+	defer iter.mu.Unlock()
+
 	var inspectMinute MinuteCheckPoint
 
 	// this is initial condition when no checkpoint exists in the window
@@ -102,20 +114,27 @@ func (iter *QueryIterator[OK, ERR]) populateNextNonEmpty() {
 
 func (iter *QueryIterator[OK, ERR]) Next() (OK, ERR) {
 	// This assumes that there is always a next index to fetch if this function is called
+	iter.mu.Lock()
 	iter.index++
 	currentMinute := iter.windows[iter.index]
-	if iter.index == len(iter.windows)-1 {
+	populateNext := iter.index == len(iter.windows)-1
+	if populateNext {
 		iter.ready = false
+	}
+	iter.mu.Unlock()
+	if populateNext {
 		go iter.populateNextNonEmpty()
 	}
 	return iter.queryRunner(currentMinute.time, currentMinute.time.Add(time.Minute))
 }
 
 func (iter *QueryIterator[OK, ERR]) Prev() (OK, ERR) {
+	iter.mu.Lock()
 	if iter.index > 0 {
 		iter.index--
 	}
 	currentMinute := iter.windows[iter.index]
+	iter.mu.Unlock()
 	return iter.queryRunner(currentMinute.time, currentMinute.time.Add(time.Minute))
 }
 

--- a/pkg/model/savedQueries.go
+++ b/pkg/model/savedQueries.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"strings"
 
 	"github.com/parseablehq/pb/pkg/config"
@@ -275,7 +276,7 @@ func (m modelSavedQueries) View() string {
 func SavedQueriesMenu() *tea.Program {
 	userConfig, err := config.ReadConfigFromFile()
 	if err != nil {
-		fmt.Println("Error reading Default Profile")
+		fmt.Fprintln(os.Stderr, "Error reading Default Profile")
 	}
 	var userProfile config.Profile
 	if profile, ok := userConfig.Profiles[userConfig.DefaultProfile]; ok {
@@ -298,27 +299,27 @@ func SavedQueriesMenu() *tea.Program {
 func fetchFilters(client *internalHTTP.HTTPClient) []list.Item {
 	req, err := client.NewRequest("GET", "filters", nil)
 	if err != nil {
-		fmt.Println("Error creating request:", err)
+		fmt.Fprintln(os.Stderr, "Error creating request:", err)
 		return nil
 	}
 
 	resp, err := client.Client.Do(req)
 	if err != nil {
-		fmt.Println("Error making request:", err)
+		fmt.Fprintln(os.Stderr, "Error making request:", err)
 		return nil
 	}
 	defer resp.Body.Close()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		fmt.Println("Error reading response body:", err)
+		fmt.Fprintln(os.Stderr, "Error reading response body:", err)
 		return nil
 	}
 
 	var filters []Filter
 	err = json.Unmarshal(body, &filters)
 	if err != nil {
-		fmt.Println("Error unmarshalling response:", err)
+		fmt.Fprintln(os.Stderr, "Error unmarshalling response:", err)
 		return nil
 	}
 


### PR DESCRIPTION
## Summary

  Makes `pb` safer and more predictable for agents, scripts, and CI while preserving the existing human-readable CLI experience.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an `agent` command that provides machine-readable help, read-only command discovery, permissions, arguments, constraints, and error details.
  * Added consistent JSON output and structured error responses across CLI commands.
  * Documented automation behavior, JSON streaming, health-based exit statuses, and error formats.

* **Bug Fixes**
  * Commands now correctly report HTTP, authentication, missing-resource, timeout, and invalid-input failures instead of silently succeeding.
  * Improved handling of empty JSON collections and malformed server responses.
  * Standardized output and error streams for clearer command-line behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->