### PR TITLE
fix: /role endpoint to /roles

### DIFF
--- a/cmd/role.go
+++ b/cmd/role.go
@@ -430,7 +430,7 @@ func orDash(value string) string {
 }
 
 func fetchRoles(client *internalHTTP.HTTPClient, data *[]string) error {
-	req, err := client.NewRequest("GET", "role", nil)
+	req, err := client.NewRequest("GET", "roles", nil)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Changes

- `/role`  endpoint is deprecated, replacing with `/roles`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected role retrieval to use the proper roles endpoint, improving successful loading of available roles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->